### PR TITLE
feat(simulator-api): autoregistro al boot + sync de nombre desde backend

### DIFF
--- a/2026MVP/Assets/Custom/GameManager.cs
+++ b/2026MVP/Assets/Custom/GameManager.cs
@@ -65,6 +65,13 @@ public class GameManager : MonoBehaviour
 
     IEnumerator HeartbeatLoop()
     {
+        // Boot register: crea el record en backend si no existe (con name
+        // default derivado del pcId) y sincroniza el name canónico desde el
+        // backend. Sin esto, una PC nueva nunca aparecería en el portal hasta
+        // que un operador abriera F10. NO manda name — el backend usa
+        // if_not_exists para no pisar renames hechos desde el portal admin.
+        yield return StartCoroutine(SimulatorApiClient.SendBootRegister());
+
         // Primer heartbeat inmediato
         yield return StartCoroutine(SimulatorApiClient.SendHeartbeat());
 

--- a/2026MVP/Assets/Custom/SimulatorApiClient.cs
+++ b/2026MVP/Assets/Custom/SimulatorApiClient.cs
@@ -433,8 +433,20 @@ public static class SimulatorApiClient
     private class HeartbeatResponse
     {
         public bool ok;
+        public string name;
         public PendingConfig pendingConfig;
         public PendingUpdateData pendingUpdate;
+    }
+
+    [System.Serializable]
+    private class RegisterResponse
+    {
+        public bool success;
+        public string pcId;
+        public string name;
+        public string simulatorId;
+        public string simulatorName;
+        public bool created;
     }
 
     [System.Serializable]
@@ -505,6 +517,15 @@ public static class SimulatorApiClient
             {
                 var response = JsonUtility.FromJson<HeartbeatResponse>(request.downloadHandler.text);
 
+                // Sincronizar name canónico desde backend (ver register/PATCH admin).
+                // Backend es source-of-truth — Unity sólo refleja.
+                if (response != null && !string.IsNullOrEmpty(response.name) && response.name != config.name)
+                {
+                    Debug.Log($"[SimulatorAPI] Nombre PC sincronizado: {config.name} → {response.name}");
+                    config.name = response.name;
+                    SimulatorConfig.Instance.Save();
+                }
+
                 // Procesar pending update si existe
                 if (response?.pendingUpdate != null && !string.IsNullOrEmpty(response.pendingUpdate.version))
                 {
@@ -520,10 +541,13 @@ public static class SimulatorApiClient
 
                     newEnv = response.pendingConfig.environment;
                     newRegUrl = $"{config.apiBaseUrl}/simulator/register";
+                    // Re-register tras cambio de ambiente: NO mandar name. Backend
+                    // usa if_not_exists para preservar el name actual (que en el
+                    // ambiente nuevo puede no existir todavía → seed con default).
                     newRegJson = JsonUtility.ToJson(new RegisterRequest
                     {
                         pcId = config.pcId,
-                        name = config.name,
+                        name = "",
                         appVersion = UnityEngine.Application.version,
                         platform = "windows"
                     });
@@ -561,6 +585,70 @@ public static class SimulatorApiClient
         public string name;
         public string appVersion;
         public string platform;
+    }
+
+    /// <summary>
+    /// POST /simulator/register al arranque, SIN mandar name. El backend crea
+    /// el record si no existe (con un name default derivado del pcId) y
+    /// preserva el actual si ya existe (no pisa renames hechos desde el portal
+    /// admin). El name canónico viene en la response y se sincroniza local.
+    /// </summary>
+    public static IEnumerator SendBootRegister()
+    {
+        var config = SimulatorConfig.Instance?.data;
+        if (config == null || string.IsNullOrEmpty(config.pcId)) yield break;
+
+        string url = $"{BaseUrl}/simulator/register";
+        string json = JsonUtility.ToJson(new RegisterRequest
+        {
+            pcId = config.pcId,
+            // name vacío → backend usa if_not_exists. NO autoridad sobre el
+            // name desde un boot — sólo F10 explícito y PATCH admin lo cambian.
+            name = "",
+            appVersion = UnityEngine.Application.version,
+            platform = "windows",
+        });
+
+        using (var request = new UnityWebRequest(url, "POST"))
+        {
+            request.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(json));
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.timeout = 10;
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogWarning($"[SimulatorAPI] Boot register failed: {request.error}");
+                yield break;
+            }
+
+            try
+            {
+                var response = JsonUtility.FromJson<RegisterResponse>(request.downloadHandler.text);
+                if (response != null)
+                {
+                    bool changed = false;
+                    if (!string.IsNullOrEmpty(response.name) && response.name != config.name)
+                    {
+                        Debug.Log($"[SimulatorAPI] Nombre PC sincronizado al boot: {config.name} → {response.name}");
+                        config.name = response.name;
+                        changed = true;
+                    }
+                    if (!string.IsNullOrEmpty(response.simulatorId) && response.simulatorId != config.simulatorId)
+                    {
+                        config.simulatorId = response.simulatorId;
+                        config.simulatorName = response.simulatorName ?? "";
+                        changed = true;
+                    }
+                    if (changed) SimulatorConfig.Instance.Save();
+                }
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"[SimulatorAPI] Error parseando boot register response: {e.Message}");
+            }
+        }
     }
 
     // ── API: Solicitar URL de descarga de update ──────────────────────


### PR DESCRIPTION
## Summary

- **`SendBootRegister()`**: nuevo método público en `SimulatorApiClient`. Llamado por `GameManager.HeartbeatLoop` antes del primer heartbeat. POST `/simulator/register` SIN mandar name → backend crea record si no existe (con name default derivado del pcId) y preserva el actual si ya existe (no pisa renames hechos desde el portal admin).
- **`HeartbeatResponse.name` + `RegisterResponse.name`**: el backend devuelve el name canónico, Unity sincroniza `simulator_config.json` local si difiere. Backend es source-of-truth.
- **Re-register tras `pendingConfig`** (cambio de ambiente): omite name para no pisar renames del admin con el cache local de Unity.

Antes una PC nueva sólo aparecía en backend si alguien abría F10. Ahora aparece en cuanto Unity arranca con red.

Requiere PR backend `feat(pcs): rename remoto + autoregistro al boot` deployado para que `/simulator/register` acepte body sin `name` y devuelva el campo en response.

## Test plan

- [ ] Compila en Unity Editor (Windows target)
- [ ] PC nueva (sin record en DDB): bootear Unity → ver record creado en `/admin/simuladores/pcs` con name `PC-XXXXXX`
- [ ] PC existente: bootear Unity → name local sincroniza al canónico del backend
- [ ] Renombrar desde portal con Unity online → próximo heartbeat aplica el cambio en `simulator_config.json`
- [ ] Renombrar desde portal con Unity offline → al boot, `SendBootRegister` no pisa, heartbeat siguiente sincroniza local
- [ ] F10 OnAdminSave seguir funcionando como rename explícito (sin cambios en ese path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)