### PR TITLE
feat(menu): spawn por sufijo — códigos 0000X..4444X mapean a 5 ubicaciones Gley

### DIFF
--- a/2026MVP/Assets/Custom/GameManager.cs
+++ b/2026MVP/Assets/Custom/GameManager.cs
@@ -29,6 +29,9 @@ public class GameManager : MonoBehaviour
     /// <summary>ID del simulador asignado (de backend).</summary>
     public string SimulatorId { get; set; }
 
+    /// <summary>0 = aleatorio entre 1..5; 1..5 = waypoint fijo. Default 1 (legacy).</summary>
+    public int LocationId { get; set; } = 1;
+
     void Awake()
     {
         if (Instance == null)
@@ -115,5 +118,6 @@ public class GameManager : MonoBehaviour
         CitizenName = null;
         LicenseType = null;
         SessionId = null;
+        LocationId = 1;
     }
 }

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
@@ -712,6 +713,7 @@ public class MenuScreenManager : MonoBehaviour
                 tramiteId = response.tramiteId;
                 citizenName = response.citizenName;
                 licenseType = response.licenseType;
+                GameManager.Instance.LocationId = 1;
                 OnSessionVerified();
                 yield break;
             }
@@ -724,16 +726,32 @@ public class MenuScreenManager : MonoBehaviour
         }
     }
 
+    // Demo codes: prefijo de 4 dígitos → (tramiteId, citizenName, licenseType).
+    // El 5° dígito es el sufijo de ubicación: 0 = aleatorio, 1..5 = spawn fijo.
+    static readonly Dictionary<string, (string id, string name, string type)> DEMO_PREFIXES = new Dictionary<string, (string, string, string)>
+    {
+        { "0000", ("TLX-DEMO00000", "Demo Automóvil",  "particular")  },
+        { "1111", ("TLX-DEMO11111", "Demo Pasajeros",  "publico")     },
+        { "2222", ("TLX-DEMO22222", "Demo Moto",       "motocicleta") },
+        { "3333", ("TLX-DEMO33333", "Demo Carga",      "carga")       },
+        { "4444", ("TLX-DEMO44444", "Demo Ambulancia", "emergencia")  },
+    };
+
     void OnVerifyCode()
     {
         string code = codeInput != null ? codeInput.text.Trim().ToUpper() : "";
 
-        // Demo codes para testing sin backend
-        if (code == "00000") { tramiteId = "TLX-DEMO00000"; citizenName = "Demo Automóvil"; licenseType = "particular"; OnSessionVerified(); return; }
-        if (code == "11111") { tramiteId = "TLX-DEMO11111"; citizenName = "Demo Pasajeros"; licenseType = "publico"; OnSessionVerified(); return; }
-        if (code == "22222") { tramiteId = "TLX-DEMO22222"; citizenName = "Demo Moto"; licenseType = "motocicleta"; OnSessionVerified(); return; }
-        if (code == "33333") { tramiteId = "TLX-DEMO33333"; citizenName = "Demo Carga"; licenseType = "carga"; OnSessionVerified(); return; }
-        if (code == "44444") { tramiteId = "TLX-DEMO44444"; citizenName = "Demo Ambulancia"; licenseType = "emergencia"; OnSessionVerified(); return; }
+        // Demo codes para testing sin backend (5 dígitos: 4 de tipo + 1 de ubicación 0..5)
+        if (code.Length == 5 && DEMO_PREFIXES.TryGetValue(code.Substring(0, 4), out var demo)
+            && code[4] >= '0' && code[4] <= '5')
+        {
+            tramiteId = demo.id;
+            citizenName = demo.name;
+            licenseType = demo.type;
+            GameManager.Instance.LocationId = code[4] - '0';
+            OnSessionVerified();
+            return;
+        }
 
         if (string.IsNullOrEmpty(code))
         {
@@ -774,6 +792,7 @@ public class MenuScreenManager : MonoBehaviour
         tramiteId = response.tramiteId;
         citizenName = response.citizenName;
         licenseType = response.licenseType;
+        GameManager.Instance.LocationId = 1;
         OnSessionVerified();
     }
 

--- a/2026MVP/Assets/Custom/SpawnLocationManager.cs
+++ b/2026MVP/Assets/Custom/SpawnLocationManager.cs
@@ -1,0 +1,244 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.SceneManagement;
+using Gley.UrbanSystem;
+using TrafficAPI = Gley.TrafficSystem.API;
+using TrafficWaypoint = Gley.TrafficSystem.TrafficWaypoint;
+
+/// <summary>
+/// Teleporta el vehículo del jugador a uno de 5 waypoints predefinidos al cargar
+/// una escena de manejo, según GameManager.LocationId (1..5; 0 = aleatorio).
+///
+/// Reusa la red de waypoints de Gley TrafficSystem ya cargada en cada escena —
+/// no requiere editar el .unity ni colocar GameObjects manualmente.
+/// </summary>
+public static class SpawnLocationManager
+{
+    static bool subscribed;
+
+    // Índices distribuidos en la red de waypoints de Gley UrbanExample.
+    // Para refinar un slot: maneja a la zona deseada y presiona [K] — log
+    // en F7 imprime el índice del waypoint más cercano al Player. Cambia
+    // el entero correspondiente y rebuildea.
+    //   slot 1 = 11111 (legacy)                  slot 2 = 11112 (zona 2)
+    //   slot 3 = 11113 (antes de glorieta)       slot 4 = 11114
+    //   slot 5 = 11115
+    // -1 = sin asignar (placeholder). El runner deja el spawn original cuando
+    // el slot vale -1 — así un código demo con sufijo TBD no manda al jugador
+    // a un waypoint arbitrario (especialmente el índice 0, que es válido en
+    // Gley pero rara vez es la zona deseada).
+    const int UNASSIGNED = -1;
+    static readonly int[] DEFAULT_WAYPOINTS = { UNASSIGNED, 6765, 3170, UNASSIGNED, UNASSIGNED };
+
+    // Override por escena solo si el mapa Gley difiere (ej. moto). Si no aparece
+    // aquí, se usa DEFAULT_WAYPOINTS.
+    static readonly Dictionary<string, int[]> WAYPOINT_OVERRIDES = new Dictionary<string, int[]>
+    {
+        // { "Motocicleta", new[] { 5, 30, 60, 90, 120 } },
+    };
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void Bootstrap()
+    {
+        if (subscribed) return;
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        subscribed = true;
+
+        string current = SceneManager.GetActiveScene().name;
+        if (IsDrivingScene(current))
+        {
+            EnsureWaypointDebugger();
+            Schedule(current);
+        }
+    }
+
+    // El debugger y el runner viven SOLO en la escena de manejo. Cuando la
+    // escena se descarga (volver al MainMenu), Unity los destruye junto con
+    // el resto de la escena — no usamos DontDestroyOnLoad porque entonces
+    // sobrevivirían al unload de Gley y crashearían al tocar TrafficAPI.
+    static void EnsureWaypointDebugger()
+    {
+        if (Object.FindFirstObjectByType<WaypointDebugger>() != null) return;
+        var go = new GameObject("WaypointDebugger");
+        go.AddComponent<WaypointDebugger>();
+    }
+
+    static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (IsDrivingScene(scene.name))
+        {
+            EnsureWaypointDebugger();
+            Schedule(scene.name);
+        }
+    }
+
+    // Whitelist explícita de escenas donde inyectamos el spawn manager + debugger.
+    // Mejor que excluir MainMenu/SampleScene: si mañana alguien agrega una escena
+    // de loading/calibración/resultados, no dispara accidentalmente.
+    static readonly HashSet<string> DRIVING_SCENES = new HashSet<string>
+    {
+        "Sedan", "Camioneta", "Motocicleta",
+        "BusPasajeros", "CamionDCarga", "Ambulancia",
+    };
+
+    internal static bool IsDrivingScene(string sceneName)
+    {
+        return DRIVING_SCENES.Contains(sceneName);
+    }
+
+    static void Schedule(string sceneName)
+    {
+        // Guard: evitar doble runner si por alguna razón sceneLoaded dispara dos
+        // veces para la misma escena (additive load, recompilación caliente, etc.).
+        if (Object.FindFirstObjectByType<SpawnLocationRunner>() != null) return;
+
+        // Vive con la escena actual. Si volvemos al MainMenu antes de que
+        // termine la corutina, Unity destruye el GameObject y la corutina
+        // se cancela limpiamente — no toca Gley ya descargado.
+        var runner = new GameObject("SpawnLocationRunner").AddComponent<SpawnLocationRunner>();
+        runner.StartCoroutine(runner.ApplySpawn(sceneName));
+    }
+
+    internal static int[] GetWaypoints(string sceneName)
+    {
+        return WAYPOINT_OVERRIDES.TryGetValue(sceneName, out var ov) ? ov : DEFAULT_WAYPOINTS;
+    }
+}
+
+internal class SpawnLocationRunner : MonoBehaviour
+{
+    public IEnumerator ApplySpawn(string sceneName)
+    {
+        int locationId = GameManager.Instance != null ? GameManager.Instance.LocationId : 1;
+        int slot = locationId == 0 ? Random.Range(1, 6) : Mathf.Clamp(locationId, 1, 5);
+
+        int[] waypoints = SpawnLocationManager.GetWaypoints(sceneName);
+        int waypointIndex = waypoints[slot - 1];
+
+        // Slot sin asignar (placeholder TBD): no toques al jugador.
+        if (waypointIndex < 0)
+        {
+            Debug.Log($"[SpawnLocationManager] Slot {slot} sin asignar — spawn original. scene={sceneName} locationId={locationId}");
+            Destroy(gameObject);
+            yield break;
+        }
+
+        // Espera a que Gley TrafficSystem inicialice (timeout 5s).
+        float gleyTimeout = Time.unscaledTime + 5f;
+        while (Time.unscaledTime < gleyTimeout)
+        {
+            if (TrafficAPI.IsInitialized()) break;
+            yield return null;
+        }
+
+        if (!TrafficAPI.IsInitialized())
+        {
+            Debug.LogWarning($"[SpawnLocationManager] Gley no inicializó en 5s — spawn original. scene={sceneName} locationId={locationId}");
+            Destroy(gameObject);
+            yield break;
+        }
+
+        TrafficWaypoint waypoint = TrafficAPI.GetWaypointFromIndex(waypointIndex);
+        if (waypoint == null)
+        {
+            Debug.LogWarning($"[SpawnLocationManager] Waypoint {waypointIndex} inválido — spawn original. scene={sceneName} locationId={locationId}");
+            Destroy(gameObject);
+            yield break;
+        }
+
+        // El PlayerCar puede instanciarse uno o dos frames después de Gley.
+        // Reintentamos durante 2s antes de rendirnos.
+        Transform target = FindPlayerVehicle();
+        float playerTimeout = Time.unscaledTime + 2f;
+        while (target == null && Time.unscaledTime < playerTimeout)
+        {
+            yield return null;
+            target = FindPlayerVehicle();
+        }
+        if (target == null)
+        {
+            Debug.LogWarning($"[SpawnLocationManager] No se encontró Player tras 2s — spawn original. scene={sceneName}");
+            Destroy(gameObject);
+            yield break;
+        }
+
+        Vector3 pos = waypoint.Position;
+        Quaternion rot = target.rotation;
+        if (waypoint.Neighbors != null && waypoint.Neighbors.Length > 0)
+        {
+            var next = TrafficAPI.GetWaypointFromIndex(waypoint.Neighbors[0]);
+            if (next != null)
+            {
+                Vector3 forward = (next.Position - pos);
+                forward.y = 0f;
+                if (forward.sqrMagnitude > 0.001f)
+                {
+                    rot = Quaternion.LookRotation(forward.normalized, Vector3.up);
+                }
+            }
+        }
+
+        target.SetPositionAndRotation(pos, rot);
+        var rb = target.GetComponent<Rigidbody>();
+        if (rb != null)
+        {
+            rb.linearVelocity = Vector3.zero;
+            rb.angularVelocity = Vector3.zero;
+        }
+
+        Debug.Log($"[SpawnLocationManager] scene={sceneName} locationId={locationId} slot={slot} waypoint={waypointIndex} pos={pos}");
+        Destroy(gameObject);
+    }
+
+    static Transform FindPlayerVehicle()
+    {
+        var pc = Object.FindFirstObjectByType<PlayerCar>();
+        if (pc != null) return pc.transform;
+
+        var tagged = GameObject.FindWithTag("Player");
+        if (tagged != null) return tagged.transform.root;
+
+        var named = GameObject.Find("Player");
+        if (named != null) return named.transform.root;
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Helper de debug: presiona [K] para loggear el índice del waypoint Gley más
+/// cercano al Player. Útil para descubrir qué número poner en
+/// SpawnLocationManager.DEFAULT_WAYPOINTS para una zona específica (glorieta,
+/// escolar, hospital, etc.) sin tener que abrir el editor de Unity.
+/// </summary>
+internal class WaypointDebugger : MonoBehaviour
+{
+    void Update()
+    {
+        var kb = Keyboard.current;
+        if (kb == null || !kb.kKey.wasPressedThisFrame) return;
+
+        // Defensivo: si se quedó vivo durante un cambio de escena, no toques
+        // Gley a menos que la escena actual sea de manejo (whitelist).
+        if (!SpawnLocationManager.IsDrivingScene(SceneManager.GetActiveScene().name)) return;
+
+        if (!TrafficAPI.IsInitialized())
+        {
+            Debug.Log("[WaypointDebug] Gley TrafficSystem no inicializado todavía.");
+            return;
+        }
+
+        Transform t = null;
+        var pc = Object.FindFirstObjectByType<PlayerCar>();
+        if (pc != null) t = pc.transform;
+        else { var named = GameObject.Find("Player"); if (named != null) t = named.transform.root; }
+        if (t == null) { Debug.Log("[WaypointDebug] No se encontró Player."); return; }
+
+        var wp = TrafficAPI.GetClosestWaypoint(t.position);
+        if (wp == null) { Debug.Log($"[WaypointDebug] No hay waypoint cercano a {t.position}."); return; }
+
+        Debug.Log($"[WaypointDebug] Player @ {t.position} → nearest waypoint idx={wp.ListIndex} pos={wp.Position}  (úsalo en DEFAULT_WAYPOINTS)");
+    }
+}

--- a/2026MVP/Assets/Custom/SpawnLocationManager.cs.meta
+++ b/2026MVP/Assets/Custom/SpawnLocationManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0563902165dd74e8699c4177544a398e


### PR DESCRIPTION
## Summary
- 5° dígito del código demo controla ubicación de spawn (1..5 = fijo, 0 = aleatorio)
- Reusa red de waypoints de Gley TrafficSystem; no toca escenas en el editor
- Helper [K] en escenas de manejo loguea índice de waypoint cercano al Player

## Códigos
- `00001..00005`, `11111..11115`, `22221..22225`, `33331..33335`, `44441..44445` → mismo vehículo de antes + ubicación 1..5
- `00000`, `11110`, etc. → ubicación aleatoria entre slots con valor asignado
- Códigos backend reales sin sufijo → spawn original (`LocationId=1` por default)

## Estado de slots
- Slot 2 = waypoint Gley `6765`
- Slot 3 = waypoint Gley `3170` (antes de la glorieta)
- Slots 1, 4, 5 = `UNASSIGNED` → caen al spawn original hasta que se capturen los waypoints reales con [K]

## Hardenings (review codex)
- `LocationId` se resetea a 1 antes de `OnSessionVerified` en flujos backend (LookupByCode + QR poll) — evita que un sufijo demo se herede en sesión real
- Whitelist explícita de driving scenes en lugar de exclusión MainMenu/SampleScene
- Sin `DontDestroyOnLoad` — el helper y runner viven con la escena (evita crash al volver al MainMenu)
- Guard contra doble `SpawnLocationRunner`
- Retry 2s al buscar `PlayerCar` (race con orden de instanciación)
- Sentinel `UNASSIGNED=-1` para slots sin valor real

## Archivos
- `Assets/Custom/GameManager.cs` — agrega `LocationId` (default 1) + reset en `ClearSession()`
- `Assets/Custom/Menu/MenuScreenManager.cs` — refactor demo codes a tabla + parseo del 5° dígito
- `Assets/Custom/SpawnLocationManager.cs` (nuevo) — bootstrap, runner, debugger

## Test plan
- [ ] `11111` → BusPasajeros, spawn original (legacy compat)
- [ ] `11112` → BusPasajeros, waypoint 6765
- [ ] `11113` → BusPasajeros, waypoint 3170 (antes de glorieta)
- [ ] `11114` / `11115` → spawn original (UNASSIGNED), log "Slot N sin asignar"
- [ ] `11110` → aleatorio entre slots asignados
- [ ] Mismo patrón con `00000X`, `22222X`, `33333X`, `44444X`
- [ ] Código backend real (no demo) → spawn original, sin teleporte
- [ ] Terminar examen → MainMenu → escribir cualquier código → no debe crashear
- [ ] Tecla `K` en escena de manejo → log `[WaypointDebug]` aparece en F7
- [ ] Tecla `K` en MainMenu → no hace nada (whitelist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)