### PR TITLE
fix(spawn): corregir asignación slot 4 y restaurar slot 2

### DIFF
--- a/2026MVP/Assets/Custom/SpawnLocationManager.cs
+++ b/2026MVP/Assets/Custom/SpawnLocationManager.cs
@@ -30,7 +30,7 @@ public static class SpawnLocationManager
     // a un waypoint arbitrario (especialmente el índice 0, que es válido en
     // Gley pero rara vez es la zona deseada).
     const int UNASSIGNED = -1;
-    static readonly int[] DEFAULT_WAYPOINTS = { UNASSIGNED, 6765, 3170, UNASSIGNED, UNASSIGNED };
+    static readonly int[] DEFAULT_WAYPOINTS = { UNASSIGNED, 4588, 3170, 6765, UNASSIGNED };
 
     // Override por escena solo si el mapa Gley difiere (ej. moto). Si no aparece
     // aquí, se usa DEFAULT_WAYPOINTS.


### PR DESCRIPTION
## Summary
- Slot 2 vuelve a `4588` (asignación original)
- Slot 4 = `6765` (corrige interpretación errónea del PR anterior)

## Estado actualizado
- Slot 2 = `4588`
- Slot 3 = `3170` (antes de glorieta)
- Slot 4 = `6765`
- Slots 1 y 5 = UNASSIGNED → spawn original

🤖 Generated with [Claude Code](https://claude.com/claude-code)