### PR TITLE
chore(spawn): rellenar slots 1 y 5 (espejo temporal de 3 y 2)

### DIFF
--- a/2026MVP/Assets/Custom/SpawnLocationManager.cs
+++ b/2026MVP/Assets/Custom/SpawnLocationManager.cs
@@ -30,7 +30,9 @@ public static class SpawnLocationManager
     // a un waypoint arbitrario (especialmente el índice 0, que es válido en
     // Gley pero rara vez es la zona deseada).
     const int UNASSIGNED = -1;
-    static readonly int[] DEFAULT_WAYPOINTS = { UNASSIGNED, 4588, 3170, 6765, UNASSIGNED };
+    // Slots 1 y 5 reusan temporalmente los waypoints de 3 y 2 hasta que se
+    // capturen los puntos definitivos con la tecla [K].
+    static readonly int[] DEFAULT_WAYPOINTS = { 3170, 4588, 3170, 6765, 4588 };
 
     // Override por escena solo si el mapa Gley difiere (ej. moto). Si no aparece
     // aquí, se usa DEFAULT_WAYPOINTS.


### PR DESCRIPTION
## Summary
- Slot 1 = 3170 (mismo que slot 3, antes de glorieta)
- Slot 5 = 4588 (mismo que slot 2)
- Slots 2, 3, 4 sin cambios
- Sufijo 0 (random) ahora elige entre 5 ubicaciones reales (antes algunas caían al spawn original por ser UNASSIGNED)

Temporal hasta que se capturen waypoints definitivos para slots 1 y 5 con la tecla `K`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)