### PR TITLE
docs: documentar feature spawn por sufijo

### DIFF
--- a/2026MVP/CLAUDE.md
+++ b/2026MVP/CLAUDE.md
@@ -204,11 +204,29 @@ El menu principal (`Assets/Custom/Menu/MenuScreenManager.cs`) se auto-adjunta al
 - **QR**: POST `/kiosk/sessions` → genera QR → poll cada 10s → al verificarse obtiene `tramiteId`, `citizenName`, `licenseType`
 - **Codigo manual**: Input "TLX-XXXXXX" → GET `/simulator/lookup?code={code}` → misma info
 - **Demo codes** (5 digitos, normalizados con `.Trim().ToUpper()`):
-  - `00000` → `TLX-DEMO00000` "Demo Automovil" `particular` (abre Pantalla 1 de seleccion de modelo)
-  - `11111` → `TLX-DEMO11111` "Demo Pasajeros" `publico` (escena `BusPasajeros`)
-  - `22222` → `TLX-DEMO22222` "Demo Moto" `motocicleta` (escena `Motocicleta`)
-  - `33333` → `TLX-DEMO33333` "Demo Carga" `carga` (escena `CamionDCarga`)
-  - `44444` → `TLX-DEMO44444` "Demo Ambulancia" `emergencia` (escena `Ambulancia`)
+  - **Primeros 4 digitos = tipo de licencia/vehiculo**, **5° digito = ubicacion de spawn (0..5)**.
+  - `0000X` → `TLX-DEMO00000` "Demo Automovil" `particular` (abre Pantalla 1 de seleccion de modelo)
+  - `1111X` → `TLX-DEMO11111` "Demo Pasajeros" `publico` (escena `BusPasajeros`)
+  - `2222X` → `TLX-DEMO22222` "Demo Moto" `motocicleta` (escena `Motocicleta`)
+  - `3333X` → `TLX-DEMO33333` "Demo Carga" `carga` (escena `CamionDCarga`)
+  - `4444X` → `TLX-DEMO44444` "Demo Ambulancia" `emergencia` (escena `Ambulancia`)
+  - **Sufijo X**: `1..5` = waypoint Gley fijo (ver `SpawnLocationManager.DEFAULT_WAYPOINTS`), `0` = aleatorio entre los 5. Cualquier otro digito (`6..9`) cae al flujo backend normal.
+  - Compat: `11111` sigue valido (= zona 1), `22222`, etc.
+
+### Spawn por sufijo (ubicaciones en la ciudad)
+
+`Assets/Custom/SpawnLocationManager.cs` (singleton bootstrap, post-merge feature/spawn-locations-by-suffix):
+
+- Lee `GameManager.LocationId` (1..5 = fijo, 0 = random) y teleporta al `Player` (busca por `Gley.UrbanSystem.PlayerCar` → tag `Player` → name `Player`) al waypoint Gley correspondiente.
+- Reusa la red de Gley TrafficSystem ya cargada — no requiere editar las escenas en el editor.
+- Tabla `DEFAULT_WAYPOINTS = { 3170, 4588, 3170, 6765, 4588 }` (slots 1..5; slots 1 y 5 son espejo temporal de 3 y 2 hasta capturar puntos definitivos).
+- Solo activo en escenas whitelist: `Sedan`, `Camioneta`, `Motocicleta`, `BusPasajeros`, `CamionDCarga`, `Ambulancia`. En MainMenu nunca se inyecta.
+- Usa `UNASSIGNED = -1` como sentinel: si el slot vale `-1`, el runner deja el spawn original (legacy).
+- `LocationId` se resetea a `1` antes de `OnSessionVerified` en flujos backend (LookupByCode + QR poll) para no heredar sufijo de demos previos.
+
+**Helper de debug**: tecla `K` en escena de manejo loguea `[WaypointDebug] ... idx=NNN ...` con el waypoint Gley mas cercano al Player. Util para descubrir indices y refinar `DEFAULT_WAYPOINTS` sin abrir el editor.
+
+**Bug evitado** (no repetir): la version inicial usaba `DontDestroyOnLoad` en el debugger/runner → al volver al MainMenu seguian vivos y `WaypointDebugger.Update()` tocaba `TrafficAPI.GetClosestWaypoint()` con Gley descargado → race / NRE / crash. Solucion actual: sin `DontDestroyOnLoad` + guard whitelist en `Update()`.
 - **Clima**: aleatorio (`PlayerPrefs["Cargolluvia"] = Random.Range(0,2)`)
 - Si `licenseType == "particular"` → Pantalla 1. Si otro → directo a Pantalla 2
 

--- a/2026MVP/ManualUsuario.md
+++ b/2026MVP/ManualUsuario.md
@@ -27,14 +27,34 @@ Al iniciar la aplicacion, aparece la pantalla **"Prueba de Manejo"** con dos opc
 
 ## Codigos Demo (para pruebas sin backend)
 
-Estos codigos funcionan sin conexion al servidor:
+Estos codigos funcionan sin conexion al servidor. **Los primeros 4 digitos** definen el tipo de licencia / vehiculo; **el 5° digito** controla en que parte de la ciudad arranca el examinado.
 
-| Codigo | Tipo de licencia | Escena |
-|--------|-----------------|--------|
-| `00000` | Particular (Automovil) | Sedan / Jetta / Camioneta |
-| `11111` | Publico (Pasajeros) | Bus de Pasajeros |
-| `22222` | Motocicleta | Motocicleta |
-| `33333` | Carga (Camion) | Camion de Carga |
+| Prefijo (4 digitos) | Tipo de licencia | Escena |
+|---|---|---|
+| `0000X` | Particular (Automovil) | Sedan / Jetta / Camioneta |
+| `1111X` | Publico (Pasajeros) | Bus de Pasajeros |
+| `2222X` | Motocicleta | Motocicleta |
+| `3333X` | Carga (Camion) | Camion de Carga |
+| `4444X` | Emergencia | Ambulancia |
+
+### Sufijo de ubicacion (5° digito)
+
+| Sufijo | Comportamiento |
+|---|---|
+| `1` | Spawn fijo en zona 1 |
+| `2` | Spawn fijo en zona 2 |
+| `3` | Spawn fijo en zona 3 (antes de la glorieta) |
+| `4` | Spawn fijo en zona 4 |
+| `5` | Spawn fijo en zona 5 |
+| `0` | Aleatorio entre las 5 zonas |
+| `6..9` | No es demo: el sistema lo manda al backend como codigo real |
+
+Ejemplos:
+- `11113` → Bus en la zona 3 (antes de la glorieta).
+- `22220` → Motocicleta en zona aleatoria.
+- `00001` → Auto en zona 1.
+
+Para descubrir o refinar los waypoints de cada zona: durante un examen, posiciona el vehiculo donde quieras que arranque y presiona la tecla **`K`**. En la consola F7 aparece `[WaypointDebug] ... idx=NNN ...` — ese numero se hardcodea en `Assets/Custom/SpawnLocationManager.cs` (`DEFAULT_WAYPOINTS`).
 
 ---
 


### PR DESCRIPTION
## Summary
- Actualiza `2026MVP/CLAUDE.md` con la nueva sección "Spawn por sufijo (ubicaciones en la ciudad)" — explica `SpawnLocationManager`, tabla `DEFAULT_WAYPOINTS`, helper `K` y por qué no se usa `DontDestroyOnLoad`.
- Actualiza `2026MVP/ManualUsuario.md`: tabla de demo codes refleja prefijo + sufijo de ubicación, agrega tabla con cada sufijo (1..5 fijo, 0 random, 6..9 backend) y ejemplos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)