### PR TITLE
fix(spawn): waypoints definitivos para slots 1 y 5

### DIFF
--- a/2026MVP/Assets/Custom/SpawnLocationManager.cs
+++ b/2026MVP/Assets/Custom/SpawnLocationManager.cs
@@ -30,9 +30,7 @@ public static class SpawnLocationManager
     // a un waypoint arbitrario (especialmente el índice 0, que es válido en
     // Gley pero rara vez es la zona deseada).
     const int UNASSIGNED = -1;
-    // Slots 1 y 5 reusan temporalmente los waypoints de 3 y 2 hasta que se
-    // capturen los puntos definitivos con la tecla [K].
-    static readonly int[] DEFAULT_WAYPOINTS = { 3170, 4588, 3170, 6765, 4588 };
+    static readonly int[] DEFAULT_WAYPOINTS = { 6953, 4588, 3170, 6765, 3016 };
 
     // Override por escena solo si el mapa Gley difiere (ej. moto). Si no aparece
     // aquí, se usa DEFAULT_WAYPOINTS.


### PR DESCRIPTION
## Summary

- Reemplaza los placeholders duplicados de los slots 1 y 5 en `DEFAULT_WAYPOINTS` por los waypoints capturados con [K]:
  - **slot 1** = `6953` en `(-6.07, 0.50, 84.69)`
  - **slot 5** = `3016` en `(-1.78, 0.25, -239.96)`
- Los 5 slots ya apuntan a posiciones distintas; se elimina el comentario obsoleto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)