### PR TITLE
fix(hud): límite de velocidad de 3 dígitos en una sola línea

### DIFF
--- a/2026MVP/Assets/Custom/SpeedometerSetup.cs
+++ b/2026MVP/Assets/Custom/SpeedometerSetup.cs
@@ -138,6 +138,11 @@ public class SpeedometerSetup : MonoBehaviour
         limitTmp.verticalAlignment = VerticalAlignmentOptions.Middle;
         limitTmp.color = Color.black;
         limitTmp.raycastTarget = false;
+        limitTmp.enableWordWrapping = false;
+        limitTmp.overflowMode = TextOverflowModes.Overflow;
+        limitTmp.enableAutoSizing = true;
+        limitTmp.fontSizeMin = 18f;
+        limitTmp.fontSizeMax = 32f;
 
         // Add the display script
         SpeedLimitDisplay displayScript = signObj.AddComponent<SpeedLimitDisplay>();

--- a/2026MVP/Assets/Custom/TopHudRow.cs
+++ b/2026MVP/Assets/Custom/TopHudRow.cs
@@ -200,6 +200,13 @@ public class TopHudRow : MonoBehaviour
         tmp.verticalAlignment = VerticalAlignmentOptions.Middle;
         tmp.color = Color.black;
         tmp.raycastTarget = false;
+        // Sin wrap + auto-size: límites de 3 dígitos (110, 120) se escalan en una sola
+        // línea en vez de partirse en "11" / "0".
+        tmp.enableWordWrapping = false;
+        tmp.overflowMode = TextOverflowModes.Overflow;
+        tmp.enableAutoSizing = true;
+        tmp.fontSizeMin = 32f;
+        tmp.fontSizeMax = 58f;
         if (font != null) tmp.font = font;
 
         speedLimit = go.AddComponent<SpeedLimitDisplay>();


### PR DESCRIPTION
## Summary
- El número del letrero de límite de velocidad se partía en 2 líneas cuando tenía 3 dígitos (zonas de 110/120 km/h aparecían como "11" / "0").
- Causa: `TextMeshProUGUI` con word-wrap por defecto y RectTransform que solo usa el 70% del ancho del slot (~98px). A 58pt bold, "110" no cabe horizontalmente.
- Fix: `enableWordWrapping = false` + auto-size con rango 32-58pt en `TopHudRow.cs` (HUD activo) y `SpeedometerSetup.cs` (legacy editor-only). "40" se queda a 58pt, "110"/"120" se reducen automáticamente para entrar en una sola línea dentro del círculo.

## Test plan
- [ ] Entrar a una escena de manejo y verificar que zonas con límite de 3 dígitos (autopista 110, etc.) se muestran en una línea.
- [ ] Verificar que "40", "30", "20" siguen viéndose grandes (no se redujeron innecesariamente).
- [ ] Confirmar visualmente que el número queda centrado dentro del círculo rojo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)