### PR TITLE
feat(violations): distinguir colisión activa vs pasiva

### DIFF
--- a/2026MVP/Assets/Custom/ExamResultsScreen.cs
+++ b/2026MVP/Assets/Custom/ExamResultsScreen.cs
@@ -283,10 +283,14 @@ public class ExamResultsScreen : MonoBehaviour
                 rowBg.raycastTarget = false;
             }
 
+            // Pasivas o eventos con 0 puntos: mostrar "—" en vez de "-0".
+            string ptsLabel = fault.points == 0
+                ? "—"
+                : "-" + Mathf.Abs(fault.points).ToString();
             BuildTableRow(row.transform,
                 FormatTimestamp(fault.timestamp),
                 fault.description,
-                "-" + Mathf.Abs(fault.points).ToString(),
+                ptsLabel,
                 isHeader: false,
                 severity: GetSeverity(fault.eventType),
                 points: fault.points);
@@ -382,7 +386,12 @@ public class ExamResultsScreen : MonoBehaviour
         var all = TelemetryLogger.Instance.data.events;
         for (int i = 0; i < all.Count; i++)
         {
-            if (all[i] != null && all[i].points < 0) result.Add(all[i]);
+            var e = all[i];
+            if (e == null) continue;
+            // Las pasivas se incluyen aunque tengan points==0 — el alumno
+            // sintió el cristal roto/shake/FFB, debe ver la entrada listada
+            // para entender que el sistema lo registró pero no lo penalizó.
+            if (e.points < 0 || e.eventType == "COLISION_PASIVA") result.Add(e);
         }
         return result;
     }
@@ -399,6 +408,11 @@ public class ExamResultsScreen : MonoBehaviour
             case "SENTIDO_CONTRARIO":
             case "CAMBIO_PELIGROSO":
                 return SeverityKind.Major;
+            // Pasiva: badge Minor (amarillo) — visualmente distinto del rojo
+            // de la activa pero sin gritar al alumno por algo que no fue su
+            // falta. El símbolo en la columna Puntos será "—" en vez de "-0".
+            case "COLISION_PASIVA":
+                return SeverityKind.Minor;
             default:
                 return SeverityKind.Minor;
         }

--- a/2026MVP/Assets/Custom/ScoringConfig.cs
+++ b/2026MVP/Assets/Custom/ScoringConfig.cs
@@ -18,6 +18,11 @@ public class ScoringConfig : MonoBehaviour
         public int pedestrianHit = 25;
         public int bicycleCollision = 15;
         public int vehicleCollision = 10;
+        // Colisión vehicular pasiva: NPC embistió al alumno por atrás.
+        // Default 0 (no penaliza, solo se registra). El examinador puede
+        // subirlo desde /admin/scoring sin redeploy si en producción se
+        // decide cobrar manejo defensivo pobre.
+        public int passiveVehicleCollision = 0;
         public int signCollision = 5;
         public int obstacleCollision = 5;
         public int redLight = 20;
@@ -159,6 +164,7 @@ public class ScoringConfig : MonoBehaviour
             vd.pedestrianPenalty = data.penalties.pedestrianHit;
             vd.bicycleCollisionPenalty = data.penalties.bicycleCollision;
             vd.vehicleCollisionPenalty = data.penalties.vehicleCollision;
+            vd.passiveVehicleCollisionPenalty = data.penalties.passiveVehicleCollision;
             vd.signCollisionPenalty = data.penalties.signCollision;
             vd.obstacleCollisionPenalty = data.penalties.obstacleCollision;
             vd.dangerousGearChangePenalty = data.penalties.dangerousGearChange;

--- a/2026MVP/Assets/Custom/SimulatorApiClient.cs
+++ b/2026MVP/Assets/Custom/SimulatorApiClient.cs
@@ -212,6 +212,9 @@ public static class SimulatorApiClient
             case "ATROPELLO": return "pedestrian-hit";
             case "COLISION_BICICLETA": return "bicycle-collision";
             case "COLISION_VEHICULO": return "vehicle-collision";
+            // NO renombrar vehicle-collision → active-vehicle-collision: trámites
+            // históricos en DynamoDB ya tienen "vehicle-collision" como activa.
+            case "COLISION_PASIVA": return "passive-vehicle-collision";
             case "COLISION_SENALAMIENTO": return "sign-collision";
             case "COLISION_OBSTACULO": return "obstacle-collision";
             case "COLISION": return "collision";
@@ -234,6 +237,9 @@ public static class SimulatorApiClient
             case "COLISION":
             case "SEMAFORO_ROJO":
             case "SENTIDO_CONTRARIO": return "major";
+            // Pasiva: el alumno no la causó. La marcamos "info" para que el
+            // portal admin la pinte distinto (badge azul, no rojo).
+            case "COLISION_PASIVA": return "info";
             case "COLISION_SENALAMIENTO":
             case "COLISION_OBSTACULO":
             case "VELOCIDAD":

--- a/2026MVP/Assets/Custom/ViolationDetector.cs
+++ b/2026MVP/Assets/Custom/ViolationDetector.cs
@@ -19,6 +19,8 @@ public class ViolationDetector : MonoBehaviour
     public int pedestrianPenalty = 25;
     public int bicycleCollisionPenalty = 15;
     public int vehicleCollisionPenalty = 10;
+    [Tooltip("Colisión vehicular pasiva (NPC embistió al alumno por atrás). Default 0: no penaliza, solo se registra para que el examinador la vea.")]
+    public int passiveVehicleCollisionPenalty = 0;
     public int signCollisionPenalty = 5;
     public int obstacleCollisionPenalty = 5;
     public int dangerousGearChangePenalty = 20;
@@ -28,6 +30,10 @@ public class ViolationDetector : MonoBehaviour
     public int gearChangeWithoutClutchPenalty = 5;
     [Tooltip("Cooldown (s) solo para la penalización de rechino. El audio NO tiene cooldown — siempre suena. Evita -25 en cascada cuando el examinado practica.")]
     public float gearGrindCooldown = 3f;
+
+    [Header("Vehicle geometry")]
+    [Tooltip("Medio largo del vehículo en metros (espacio local). Sedán ~2.0, SUV ~2.3, ambulancia ~2.7, camión ~4.5, bus ~5.0, moto ~1.0. Configurable por prefab — Collider.bounds está en world space y no sirve para clasificar impacto trasero cuando el carro gira.")]
+    public float vehicleHalfLength = 2.0f;
 
     [Header("Current State (Read Only)")]
     public float currentSpeedLimit = 40f;
@@ -47,11 +53,52 @@ public class ViolationDetector : MonoBehaviour
     private float lastSpeedingTime = -999f;
     private const float SPEEDING_COOLDOWN = 5f;
 
-    // Collision cooldown — previene spam de ragdoll y objetos repetidos
-    private float lastCollisionTime = -999f;
+    // Collision cooldown — previene spam de ragdoll y objetos repetidos.
+    // Separamos activa/pasiva para que una activa real no se trague justo
+    // después de una pasiva (cadena: te embisten y rebotas contra el de
+    // adelante, ambos eventos deben registrarse).
+    private float lastActiveCollisionTime = -999f;
+    private float lastPassiveCollisionTime = -999f;
     private int lastCollisionRootId = -1;
-    private const float COLLISION_COOLDOWN = 3f;
+    private const float COLLISION_COOLDOWN_SAME = 3f;
+    private const float COLLISION_COOLDOWN_CROSS = 1f;
     private const float MIN_COLLISION_SPEED = 3f;
+
+    /// <summary>Resultado de clasificar una colisión vehicular.</summary>
+    public enum VehicleCollisionKind { Active, Passive }
+
+    /// <summary>
+    /// Heurística pura: ¿el alumno chocó (Active) o lo embistieron (Passive)?
+    /// Aislada como método estático para testear sin escena Unity.
+    ///
+    /// Pasiva = todas estas condiciones a la vez:
+    ///   1) El golpe entró por la defensa trasera (z local &lt; -halfLen·0.6).
+    ///   2) El otro se acercaba al alumno por atrás (relativeVelocity en
+    ///      forward local positiva &gt; closingThreshold).
+    ///   3) El otro venía con velocidad real (descarta empujones a 0 km/h).
+    ///   4) El otro iba más rápido que el alumno (cierre dominado por el NPC).
+    ///
+    /// `relLocal.z` se calcula con `transform.InverseTransformDirection(
+    /// collision.relativeVelocity)`. El signo se valida empíricamente en el
+    /// primer test manual — si Unity invierte el convenio, basta cambiar
+    /// `closingThreshold` por su negativo en el caller.
+    /// </summary>
+    public static VehicleCollisionKind ClassifyVehicleCollision(
+        Vector3 localPoint,
+        Vector3 relLocal,
+        float halfLen,
+        float playerSpeedKmh,
+        float npcSpeedKmh,
+        float closingThreshold = 3f)
+    {
+        bool rearImpact = localPoint.z < -halfLen * 0.6f;
+        bool closingFromBehind = relLocal.z > closingThreshold;
+        bool isPassive = rearImpact
+                      && closingFromBehind
+                      && npcSpeedKmh > 5f
+                      && npcSpeedKmh > playerSpeedKmh + 3f;
+        return isPassive ? VehicleCollisionKind.Passive : VehicleCollisionKind.Active;
+    }
 
     // RCCP integration
     private Component rccpController;
@@ -253,17 +300,17 @@ public class ViolationDetector : MonoBehaviour
 
     void OnCollisionEnter(Collision collision)
     {
-        // No penalizar si estamos parados (tráfico AI nos chocó)
+        // Velocidades de ambos lados antes del guard. Si solo el alumno está
+        // parado pero un NPC viene corriendo, sí queremos clasificar (es la
+        // queja: "me chocan por atrás cuando estoy en alto").
         float speed = GetSpeed();
-        if (speed < MIN_COLLISION_SPEED) return;
-
-        // Cooldown global: ignorar colisiones por 3s después de la última penalización
-        if (Time.time - lastCollisionTime < COLLISION_COOLDOWN) return;
+        Rigidbody otherRb = collision.rigidbody;  // ya retorna attachedRigidbody (compound colliders OK)
+        float npcSpeedKmh = otherRb != null ? otherRb.linearVelocity.magnitude * 3.6f : 0f;
+        if (speed < MIN_COLLISION_SPEED && npcSpeedKmh < MIN_COLLISION_SPEED) return;
 
         // Deduplicar por objeto raíz (ragdoll: Shin.R, Arm.L, Hips → mismo peatón)
         Transform root = collision.transform.root;
         int rootId = root.GetInstanceID();
-        if (rootId == lastCollisionRootId && Time.time - lastCollisionTime < COLLISION_COOLDOWN) return;
 
         string displayName = GetCollisionDisplayName(collision);
         GameObject rootObj = root.gameObject;
@@ -281,6 +328,38 @@ public class ViolationDetector : MonoBehaviour
         if (!isBicycle) isBicycle = direct.CompareTag("Bicicleta");
         if (!isVehicle) isVehicle = direct.CompareTag("automovil") || direct.layer == LayerMask.NameToLayer("RCCP_Vehicle");
         if (!isSign) isSign = direct.CompareTag("Senalamiento");
+
+        // Clasificar activa/pasiva SOLO para colisiones vehiculares. Las demás
+        // (peatón, bici, señal, obstáculo) son siempre culpa del alumno.
+        bool isPassive = false;
+        if (isVehicle)
+        {
+            // Punto de contacto MÁS TRASERO en espacio local del player.
+            // GetContact(0) en colisiones multipunto puede agarrar un lateral
+            // aunque la energía dominante venga de atrás — iteramos todos.
+            Vector3 localPoint = Vector3.zero;
+            float minZ = float.PositiveInfinity;
+            int contactCount = collision.contactCount;
+            for (int i = 0; i < contactCount; i++)
+            {
+                Vector3 p = transform.InverseTransformPoint(collision.GetContact(i).point);
+                if (p.z < minZ) { minZ = p.z; localPoint = p; }
+            }
+            Vector3 relLocal = transform.InverseTransformDirection(collision.relativeVelocity);
+            isPassive = ClassifyVehicleCollision(localPoint, relLocal, vehicleHalfLength, speed, npcSpeedKmh)
+                        == VehicleCollisionKind.Passive;
+        }
+
+        // Cooldown adaptativo: 3s mismo tipo, 1s cruzado.
+        // Una pasiva no debe tragarse una activa real que venga inmediatamente
+        // después (cadena de colisiones por inercia).
+        float now = Time.time;
+        float lastSame = isPassive ? lastPassiveCollisionTime : lastActiveCollisionTime;
+        float lastOther = isPassive ? lastActiveCollisionTime : lastPassiveCollisionTime;
+        if (now - lastSame < COLLISION_COOLDOWN_SAME) return;
+        if (now - lastOther < COLLISION_COOLDOWN_CROSS) return;
+        // Dedupe por objeto raíz dentro del mismo tipo
+        if (rootId == lastCollisionRootId && now - lastSame < COLLISION_COOLDOWN_SAME) return;
 
         string violationType;
         if (isPedestrian)
@@ -305,13 +384,28 @@ public class ViolationDetector : MonoBehaviour
         }
         else if (isVehicle)
         {
-            violationType = "Vehicle";
-            DeductScore(vehicleCollisionPenalty);
-            NotificationManager.Instance?.ShowNotification(
-                $"-{vehicleCollisionPenalty} ¡COLISIÓN VEHICULAR!", Color.red);
-            TelemetryLogger.Instance?.LogEvent(
-                "COLISION_VEHICULO", $"Colisión con vehículo ({displayName})",
-                -vehicleCollisionPenalty, speed);
+            if (isPassive)
+            {
+                violationType = "VehiclePassive";
+                if (passiveVehicleCollisionPenalty > 0) DeductScore(passiveVehicleCollisionPenalty);
+                NotificationManager.Instance?.ShowNotification(
+                    $"Te impactó otro vehículo ({displayName})",
+                    new Color(0.4f, 0.7f, 1f));  // azul informativo
+                TelemetryLogger.Instance?.LogEvent(
+                    "COLISION_PASIVA",
+                    $"Otro vehículo impactó al alumno por atrás ({displayName})",
+                    -passiveVehicleCollisionPenalty, speed);
+            }
+            else
+            {
+                violationType = "Vehicle";
+                DeductScore(vehicleCollisionPenalty);
+                NotificationManager.Instance?.ShowNotification(
+                    $"-{vehicleCollisionPenalty} ¡COLISIÓN VEHICULAR!", Color.red);
+                TelemetryLogger.Instance?.LogEvent(
+                    "COLISION_VEHICULO", $"Colisión con vehículo ({displayName})",
+                    -vehicleCollisionPenalty, speed);
+            }
         }
         else if (isSign)
         {
@@ -342,13 +436,16 @@ public class ViolationDetector : MonoBehaviour
             return; // No fue penalizado, no activar cooldown
         }
 
-        // Registrar cooldown
-        lastCollisionTime = Time.time;
+        // Registrar cooldown del tipo apropiado
+        if (isPassive) lastPassiveCollisionTime = now;
+        else lastActiveCollisionTime = now;
         lastCollisionRootId = rootId;
 
         // Disparar evento para CollisionFeedback (overlay/shake/flash/audio/FFB).
         // Magnitud del impulso vía Unity Physics; lateral en espacio local del vehículo
         // determina dirección del golpe direccional al volante (G923).
+        // Las pasivas también disparan feedback — el alumno DEBE sentir el golpe
+        // aunque no haya descuento (es la queja sensorial que motivó la feature).
         try
         {
             float impulseMag = collision.impulse.magnitude;


### PR DESCRIPTION
## Resumen

Hoy `ViolationDetector` descontaba puntos al alumno en CUALQUIER colisión vehicular, sin importar si él la causó o si un NPC lo embistió por atrás. Queja del usuario: el tráfico AI de Gley a veces le pega cuando está parado en alto y pierde puntos por algo que no es su falta.

Este PR introduce la distinción **activa/pasiva** para colisiones vehiculares, con cooldowns separados para que una activa real no se trague después de una pasiva en cadena.

## Heurística (ClassifyVehicleCollision, método estático puro)

Pasiva = las 3 condiciones a la vez:
- **Punto de contacto MÁS TRASERO** en espacio local del player. Threshold relativo a `vehicleHalfLength` (campo serializado por prefab — `Collider.bounds` está en world space y no sirve cuando el carro gira).
- **Velocidad relativa proyectada en forward local** > 3 m/s (el otro se acercaba activamente por atrás).
- **Velocidad cinemática del NPC** > 5 km/h Y > player + 3 km/h (cierre dominado por el NPC).

Iteramos `collision.contactCount` y elegimos el más trasero — `GetContact(0)` con multi-punto puede agarrar lateral aunque la energía dominante venga de atrás (feedback de Codex).

## Wire format

- Nuevo type `passive-vehicle-collision` en `SimulatorApiClient.MapEventType`.
- **NO** se renombra `vehicle-collision` para no romper trámites históricos en DynamoDB.
- Severidad `info` (badge azul en portal admin).

## UX

- **Notificación azul** "Te impactó otro vehículo" en pasivas (vs roja `¡COLISIÓN VEHICULAR!` en activas).
- **Feedback visceral** (cristal roto, shake, audio, FFB G923) se dispara igual en pasivas — el alumno DEBE sentir el golpe, esa fue la queja sensorial original.
- `ExamResultsScreen` lista las pasivas con puntos `—` y badge Minor.

## Coordinación con otros repos

- `portal-backend#feature/colision-activa-pasiva` — agrega `passiveVehicleCollision` al schema de Penalties.
- `simulador-licencias-portal#feature/colision-activa-pasiva` — tabla de faults en modal admin + editor de scoring.

## Test plan

- [ ] **Validación crítica**: en primer test manual, verificar signo de `Collision.relativeVelocity` proyectado en `forward` local (caso "alumno parado, NPC viene de atrás" → `relLocal.z` debe ser POSITIVO). Si sale negativo, invertir threshold en `ClassifyVehicleCollision` (1 carácter).
- [ ] Sedan parado en alto, NPC le pega por atrás → event `COLISION_PASIVA` con `-0`, cristal roto + shake disparados.
- [ ] Acelerar y embestir al NPC de adelante → event `COLISION_VEHICULO` con `-10`.
- [ ] Reversa contra NPC parado de atrás → event `COLISION_VEHICULO` (alumno reversó activamente).
- [ ] Cadena: te embisten y rebotas contra el de adelante → ambos eventos en F7 (cooldown cruzado 1s).
- [ ] Configurar `vehicleHalfLength` por prefab (sedán 2.0, SUV 2.3, ambulancia 2.7, camión 4.5, bus 5.0, moto 1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)