### PR TITLE
fix(hori): bypass Unity HID parser para throttle del HORI HPC-044U

### DIFF
--- a/2026MVP/Assets/Custom/HoriThrottleReader.cs
+++ b/2026MVP/Assets/Custom/HoriThrottleReader.cs
@@ -1,0 +1,259 @@
+// HORI Truck Control System (HPC-044U) — workaround del bug en Unity HID parser.
+//
+// Bug verificado empíricamente:
+//   - Raw HID via P/Invoke (CreateFile/ReadFile a \\?\hid#vid_0f0d&pid_017a&col01)
+//     muestra bytes 21-22 cambiando 0..65535 al pisar throttle. Confirmado con
+//     /tmp/hori-diag/hid-poll.ps1.
+//   - Unity Input System auto-genera layout para el HORI pero por los 2 sliders
+//     duplicados (HID Usage 0x36 declarado dos veces) en el descriptor, slider
+//     y slider1 alias al mismo byte (probablemente clutch byte 19-20 o brake
+//     byte 23-24). El byte del throttle (21-22) queda HUÉRFANO — ningún
+//     AxisControl lo lee, y Unity NO emite state events cuando solo el byte
+//     huérfano cambia. Verificado: HoriThrottleReader v1 con InputSystem.onEvent
+//     intercept jamás vio cambios en los bytes 21-22 aunque el usuario pisaba
+//     el throttle (los 40 events capturados solo mostraban movimiento del
+//     wheel/sticks en bytes centered).
+//
+// Solución (Plan B): bypass completo de Unity Input System. Abrimos el HID
+// device path \\?\hid#vid_0f0d&pid_017a&col01#... con CreateFile y un thread
+// background hace ReadFile loops, leyendo el raw input report. Los bytes
+// 21-22 (LE16, normalizado 0..1) van a la propiedad Value, expuesta a
+// UIInputNew via Gley.UrbanSystem.UIInputNew.HoriThrottleProvider delegate.
+//
+// Windows-only (HORI HPC-044U es Windows-only, project es Windows-only).
+
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+#define HORI_USE_PINVOKE
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+#if HORI_USE_PINVOKE
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+#endif
+
+public class HoriThrottleReader : MonoBehaviour
+{
+    static HoriThrottleReader _instance;
+    public static HoriThrottleReader Instance => _instance;
+
+    /// <summary>Throttle normalizado 0..1 (rest=0, press=1). volatile garantiza
+    /// visibilidad cross-thread (worker escribe, main thread lee).</summary>
+    public float Value => _value;
+    private volatile float _value;
+
+#if HORI_USE_PINVOKE
+    private const int VID = 0x0F0D;
+    private const int PID = 0x017A;
+
+    private SafeFileHandle _hidHandle;
+    private Thread _pollerThread;
+    private volatile bool _running;
+    private string _devicePath;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Bootstrap()
+    {
+        if (_instance != null) return;
+        var go = new GameObject("[HoriThrottleReader]");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<HoriThrottleReader>();
+        Gley.UrbanSystem.UIInputNew.HoriThrottleProvider = () =>
+            _instance != null ? _instance.Value : 0f;
+    }
+
+    void Start()
+    {
+        TryStartPoller();
+    }
+
+    void Update()
+    {
+        // Si el wheel se conectó después del start, reintentar abrir cada 2s.
+        if (_pollerThread != null && _pollerThread.IsAlive) return;
+        _retryTimer += Time.unscaledDeltaTime;
+        if (_retryTimer >= 2f)
+        {
+            _retryTimer = 0f;
+            TryStartPoller();
+        }
+    }
+
+    private float _retryTimer;
+
+    void TryStartPoller()
+    {
+        try
+        {
+            string path = FindHoriCol01Path();
+            if (string.IsNullOrEmpty(path))
+            {
+                return;  // Wheel not connected; will retry.
+            }
+            _devicePath = path;
+            _hidHandle = CreateFile(path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (_hidHandle.IsInvalid)
+            {
+                int err = Marshal.GetLastWin32Error();
+                Debug.LogWarning($"[HoriThrottleReader] CreateFile fallo path='{path}' lastError={err}");
+                _hidHandle.Dispose();
+                _hidHandle = null;
+                return;
+            }
+            _running = true;
+            _pollerThread = new Thread(PollLoop) { IsBackground = true, Name = "HoriHidPoller" };
+            _pollerThread.Start();
+            Debug.Log($"[HoriThrottleReader] Started P/Invoke poller on {path}");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[HoriThrottleReader] TryStartPoller exception: {ex.Message}");
+        }
+    }
+
+    void PollLoop()
+    {
+        byte[] buffer = new byte[64];
+        while (_running)
+        {
+            try
+            {
+                bool ok = ReadFile(_hidHandle, buffer, (uint)buffer.Length, out uint bytesRead, IntPtr.Zero);
+                if (!ok)
+                {
+                    int err = Marshal.GetLastWin32Error();
+                    if (!_running) break;
+                    Debug.LogWarning($"[HoriThrottleReader] ReadFile fallo lastError={err}, parando poller");
+                    break;
+                }
+                // Bytes 21-22 LE16 = throttle raw (verificado vía hid-poll.ps1).
+                if (bytesRead >= 23)
+                {
+                    ushort raw = (ushort)(buffer[21] | (buffer[22] << 8));
+                    _value = raw / 65535f;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_running) Debug.LogError($"[HoriThrottleReader] Poll exception: {ex.Message}");
+                break;
+            }
+        }
+        _running = false;
+        // Reset Value a 0 al perder el handle/unplug — evita aceleración fantasma
+        // si el wheel se desconecta con el throttle pisado (codex review).
+        _value = 0f;
+    }
+
+    void OnDestroy()
+    {
+        _running = false;
+        try { _hidHandle?.Dispose(); } catch {}
+        _hidHandle = null;
+        try { _pollerThread?.Join(500); } catch {}
+        _pollerThread = null;
+        if (Gley.UrbanSystem.UIInputNew.HoriThrottleProvider != null)
+            Gley.UrbanSystem.UIInputNew.HoriThrottleProvider = null;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // P/Invoke a hid.dll/setupapi.dll/kernel32.dll
+    // ─────────────────────────────────────────────────────────────────────
+
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint FILE_SHARE_READ = 0x1;
+    private const uint FILE_SHARE_WRITE = 0x2;
+    private const uint OPEN_EXISTING = 3;
+    private const uint DIGCF_PRESENT = 0x2;
+    private const uint DIGCF_DEVICEINTERFACE = 0x10;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SP_DEVICE_INTERFACE_DATA { public int cbSize; public Guid g; public uint flags; public IntPtr reserved; }
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern IntPtr SetupDiGetClassDevs(ref Guid g, IntPtr enumerator, IntPtr hwndParent, uint flags);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiEnumDeviceInterfaces(IntPtr di, IntPtr deviceInfoData, ref Guid g, uint memberIndex, ref SP_DEVICE_INTERFACE_DATA o);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr di, ref SP_DEVICE_INTERFACE_DATA d, IntPtr buf, uint bufLen, ref uint required, IntPtr deviceInfo);
+
+    [DllImport("setupapi.dll")]
+    private static extern bool SetupDiDestroyDeviceInfoList(IntPtr di);
+
+    [DllImport("hid.dll")]
+    private static extern void HidD_GetHidGuid(out Guid g);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern SafeFileHandle CreateFile(string fileName, uint access, uint share, IntPtr sa, uint creation, uint flags, IntPtr template);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ReadFile(SafeFileHandle handle, [Out] byte[] buffer, uint numBytes, out uint bytesRead, IntPtr overlapped);
+
+    static List<string> EnumerateHidPaths()
+    {
+        var paths = new List<string>();
+        Guid g; HidD_GetHidGuid(out g);
+        IntPtr di = SetupDiGetClassDevs(ref g, IntPtr.Zero, IntPtr.Zero, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (di == new IntPtr(-1)) return paths;
+        try
+        {
+            uint i = 0;
+            while (true)
+            {
+                var sdid = new SP_DEVICE_INTERFACE_DATA();
+                sdid.cbSize = Marshal.SizeOf(typeof(SP_DEVICE_INTERFACE_DATA));
+                if (!SetupDiEnumDeviceInterfaces(di, IntPtr.Zero, ref g, i++, ref sdid)) break;
+                uint req = 0;
+                SetupDiGetDeviceInterfaceDetail(di, ref sdid, IntPtr.Zero, 0, ref req, IntPtr.Zero);
+                IntPtr buf = Marshal.AllocHGlobal((int)req);
+                try
+                {
+                    Marshal.WriteInt32(buf, IntPtr.Size == 8 ? 8 : 6); // cbSize
+                    if (SetupDiGetDeviceInterfaceDetail(di, ref sdid, buf, req, ref req, IntPtr.Zero))
+                    {
+                        string p = Marshal.PtrToStringAuto(new IntPtr(buf.ToInt64() + 4));
+                        if (!string.IsNullOrEmpty(p)) paths.Add(p);
+                    }
+                }
+                finally { Marshal.FreeHGlobal(buf); }
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(di); }
+        return paths;
+    }
+
+    static string FindHoriCol01Path()
+    {
+        var paths = EnumerateHidPaths();
+        // Filtramos por VID/PID y la collection 01 (joystick interface).
+        // Format del path: \\?\hid#vid_0f0d&pid_017a&col01#...
+        string vidpid = $"vid_{VID:x4}&pid_{PID:x4}";
+        foreach (var p in paths)
+        {
+            string lower = p.ToLowerInvariant();
+            if (lower.Contains(vidpid) && lower.Contains("col01"))
+                return p;
+        }
+        return null;
+    }
+
+#else
+    // Stub para non-Windows (no-op).
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Bootstrap()
+    {
+        if (_instance != null) return;
+        var go = new GameObject("[HoriThrottleReader]");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<HoriThrottleReader>();
+        Gley.UrbanSystem.UIInputNew.HoriThrottleProvider = () => 0f;
+    }
+#endif
+}

--- a/2026MVP/Assets/Custom/HoriThrottleReader.cs.meta
+++ b/2026MVP/Assets/Custom/HoriThrottleReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 55cfb2f99ca8248e2982bf8136de9d2e

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -1473,6 +1473,12 @@ public class MenuScreenManager : MonoBehaviour
             return;
         }
 
+        // HORI Truck: NO fast-path completo. Discovery sí corre para steering/
+        // brake/clutch (esas axes Unity sí las expone). Solo el Phase 3 (gas)
+        // se auto-pasa porque el byte del throttle quedó huérfano en el HID
+        // parser y HoriThrottleReader.cs lo lee directo del state buffer.
+        // Ver gas-phase block más abajo.
+
         string currentFp = ComputeDeviceFingerprint(dev);
         string savedFp = PlayerPrefs.GetString(PREF_CAL_FINGERPRINT, "");
         bool fingerprintMatches = !string.IsNullOrEmpty(currentFp) && currentFp == savedFp;
@@ -1733,6 +1739,25 @@ public class MenuScreenManager : MonoBehaviour
         // |delta| desde su reposo (capturado al inicio de la fase).
         if (!throttleDone)
         {
+            // HORI Truck workaround: el byte del throttle (HID 21-22) quedó
+            // huérfano en el HID parser de Unity (no hay AxisControl que lo
+            // lea — verificado raw HID dump 2026-05-03). Auto-pasamos esta
+            // fase y dejamos que HoriThrottleReader.cs lea el byte directo
+            // via InputSystem.onEvent intercept. Sentinel HORI_RAW_GAS_PATH.
+            var devForGas = TryAttachToDevice();
+            if (devForGas != null && UIInputNew.IsHORITruck(devForGas))
+            {
+                throttleDone = true;
+                gasFillRT.anchorMax = new Vector2(1, 1);
+                gasFill.color = MenuTheme.IndicatorDone;
+                gasIndicator.color = MenuTheme.IndicatorDone;
+                PlayerPrefs.SetString("G923_GasAxis", UIInputNew.HORI_RAW_GAS_PATH);
+                PlayerPrefs.SetFloat("G923_GasRest", 0f);
+                PlayerPrefs.SetFloat("G923_GasPress", 1f);
+                Debug.Log($"[MenuScreenManager] HORI Truck — gas phase auto-pasada, throttle vía HoriThrottleReader (sentinel '{UIInputNew.HORI_RAW_GAS_PATH}')");
+                wheelPrompt.text = "Pisa el FRENO a fondo";
+                return;
+            }
             int bestIdx = SamplePedalCandidates(-1, out float bestAbsDelta);
             float gasProgress = Mathf.Clamp01(bestAbsDelta);
 

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -155,6 +155,9 @@ namespace Gley.UrbanSystem
         // porque el layout HID del G923 trae "::" y espacios que a veces no resuelve)
         private InputControl<float> _steerCtrl; // stick/x
         private InputControl<float> _gasCtrl;   // z
+        // HORI Truck workaround: cuando true, el gas raw value se lee de
+        // HoriThrottleReader (ya en escala 0..1) en lugar de _gasCtrl.
+        private bool _useHoriRawGas;
         private InputControl<float> _brakeCtrl; // rz
         private InputControl<float> _clutchCtrl; // stick/y en PS, null en Xbox
 
@@ -206,6 +209,21 @@ namespace Gley.UrbanSystem
 
         public const string PREF_BIND_STEER_AXIS = "Bind_steerAxis";
         public const string PREF_BIND_REVERSE = "Bind_reverse";
+
+        // Sentinel value para G923_GasAxis: el throttle del HORI HPC-044U queda
+        // huérfano en el HID parser de Unity (los 2 sliders están aliased al
+        // mismo byte y el byte del throttle 21-22 no tiene AxisControl que lo
+        // lea). HoriThrottleReader.cs (Assets/Custom/) intercepta los state
+        // events del wheel via InputSystem.onEvent y lee el byte directo.
+        // Cuando G923_GasAxis == este path, ReadGasRawValue() bypass el
+        // _gasCtrl y devuelve HoriThrottleReader.Instance.Value.
+        public const string HORI_RAW_GAS_PATH = "__HORI_RAW_HID_THROTTLE__";
+
+        // Inyección desde Assembly-CSharp (HoriThrottleReader.cs en Assets/
+        // Custom/) — cross-asmdef no permite que Gley referencie Custom, pero
+        // sí al revés. HoriThrottleReader se registra aquí en su Bootstrap.
+        // Devuelve el throttle 0..1 leído raw del HID byte 21-22.
+        public static System.Func<float> HoriThrottleProvider;
         public const string PREF_BIND_DRIVE = "Bind_drive";
         public const string PREF_BIND_PADDLE_LEFT = "Bind_paddleLeft";
         public const string PREF_BIND_PADDLE_RIGHT = "Bind_paddleRight";
@@ -538,6 +556,7 @@ namespace Gley.UrbanSystem
             _shifterDevice = null;
             _steerCtrl = null; _gasCtrl = null; _brakeCtrl = null;
             _clutchCtrl = null;
+            _useHoriRawGas = false;
             _crossCtrls = System.Array.Empty<InputControl<float>>();
             _triangleCtrl = null; _restartCtrl = null;
             _l1Ctrl = null; _r1Ctrl = null;
@@ -585,6 +604,21 @@ namespace Gley.UrbanSystem
             if (dev == null || !dev.added) return false;
             try { value = ctrl.ReadUnprocessedValue(); return true; }
             catch (System.InvalidOperationException) { return false; }
+        }
+
+        // Lectura del gas raw que respeta el bypass HORI: si _useHoriRawGas
+        // está set, lee de HoriThrottleReader (raw HID byte 21-22 → 0..1).
+        // Caso contrario, lee de _gasCtrl como antes (Logitech/moto/etc.).
+        private float ReadGasRawValue()
+        {
+            if (_useHoriRawGas)
+            {
+                // HoriThrottleProvider puede ser null en boot temprano si el
+                // singleton no se ha bootstrapped todavía — return rest.
+                var p = HoriThrottleProvider;
+                return p != null ? p() : _gasRest;
+            }
+            return SafeReadFloatRaw(_gasCtrl, out var v) ? v : _gasRest;
         }
 
         // Detecta el volante y cachea todos los controles. Idempotente:
@@ -891,11 +925,25 @@ namespace Gley.UrbanSystem
 
             if (IsHORITruck(device))
             {
-                Debug.Log("[UIInputNew] HORI Truck detectado — aplicando defaults");
+                Debug.Log("[UIInputNew] HORI Truck detectado — defaults paddle/hazard/reverse + throttle vía HoriThrottleReader (raw HID byte intercept)");
                 PlayerPrefs.SetString(PREF_BIND_PADDLE_LEFT, "button40");
                 PlayerPrefs.SetString(PREF_BIND_PADDLE_RIGHT, "button41");
                 PlayerPrefs.SetString(PREF_BIND_HAZARD, "shifter:button27");
                 PlayerPrefs.SetString(PREF_BIND_REVERSE, "shifter:button7");
+                // Throttle: el HID parser de Unity tiene un bug con el descriptor
+                // del HORI HPC-044U (sliders aliased al mismo byte) y deja el
+                // byte del throttle (21-22 del input report) huérfano — ningún
+                // AxisControl lo lee. Solución: HoriThrottleReader.cs (Assets/
+                // Custom/) intercepta los state events del wheel via InputSystem.
+                // onEvent y lee el byte directo. UIInputNew detecta este path
+                // sentinel y bypass el _gasCtrl read normal.
+                PlayerPrefs.SetString("G923_GasAxis", HORI_RAW_GAS_PATH);
+                PlayerPrefs.SetFloat("G923_GasRest",   0f);
+                PlayerPrefs.SetFloat("G923_GasPress",  1f);
+                _useHoriRawGas = true;
+                // Brake y clutch SÍ se leen via Unity (slider/slider1/rz aliased
+                // pero al menos brake y clutch responden a sus respectivos
+                // pedales). Discovery los descubre en Pantalla 2.
                 PlayerPrefs.Save();
             }
 
@@ -903,7 +951,21 @@ namespace Gley.UrbanSystem
             // (pedales). El steering path viene de PlayerPrefs via ReloadBindings().
             string gasPath   = PlayerPrefs.GetString("G923_GasAxis", "z");
             string brakePath = PlayerPrefs.GetString("G923_BrakeAxis", "rz");
-            _gasCtrl   = CacheControl(gasPath);
+            // Sentinel HORI: si gasPath quedó persistido como HORI_RAW_GAS_PATH
+            // pero el device actual NO es HORI (ej. usuario cambió de HORI a
+            // G923 sin pasar por re-discovery), invalida el sentinel para que
+            // no envenene la lectura del gas. Codex review 2026-05-03.
+            if (gasPath == HORI_RAW_GAS_PATH && !IsHORITruck(device))
+            {
+                Debug.LogWarning($"[UIInputNew] gasPath sentinel HORI persistido pero device es {device.displayName} — limpiando.");
+                PlayerPrefs.DeleteKey("G923_GasAxis");
+                PlayerPrefs.DeleteKey("G923_GasRest");
+                PlayerPrefs.DeleteKey("G923_GasPress");
+                PlayerPrefs.Save();
+                gasPath = "z";
+            }
+            _useHoriRawGas = (gasPath == HORI_RAW_GAS_PATH);
+            _gasCtrl   = _useHoriRawGas ? null : CacheControl(gasPath);
             _brakeCtrl = CacheControl(brakePath);
             // Clutch (opcional — solo G923 PS). Si no hay path en PlayerPrefs,
             // _clutchCtrl queda null → clutchInput=0 → manual sin desacople.
@@ -1287,7 +1349,7 @@ namespace Gley.UrbanSystem
                 else if (_hasWheel)
                 {
                     // Sin teclado: pedales del volante, mantener último gear
-                    float gasRaw = SafeReadFloatRaw(_gasCtrl, out var rg) ? rg : _gasRest;
+                    float gasRaw = ReadGasRawValue();
                     float brakeRaw = SafeReadFloatRaw(_brakeCtrl, out var rb) ? rb : _brakeRest;
                     float gasLinear = NormalizePedal(gasRaw, _gasRest, _gasPress);
                     // Curva del gas: pow(x, N). N<1 = más respuesta inicial, N>1 = más control fino.
@@ -1336,7 +1398,7 @@ namespace Gley.UrbanSystem
                 }
                 else if (_hasWheel)
                 {
-                    float gasRaw = SafeReadFloatRaw(_gasCtrl, out var rg) ? rg : _gasRest;
+                    float gasRaw = ReadGasRawValue();
                     float brakeRaw = SafeReadFloatRaw(_brakeCtrl, out var rb) ? rb : _brakeRest;
                     float gasLinear = NormalizePedal(gasRaw, _gasRest, _gasPress);
                     // Curva del gas: pow(x, N). N<1 = más respuesta inicial, N>1 = más control fino.
@@ -1492,7 +1554,7 @@ namespace Gley.UrbanSystem
             // Raw reads
             float leanRaw = SafeReadFloatRaw(_leanCtrl, out var rl) ? rl : 0f;
             float hbarRaw = SafeReadFloatRaw(_hbarCtrl, out var rh) ? rh : 0f;
-            float gasRaw  = SafeReadFloatRaw(_gasCtrl, out var rg) ? rg : _gasRest;
+            float gasRaw  = ReadGasRawValue();
             bool brakePressed  = SafeReadFloat(_brakeCtrl,  out var rb) && rb > 0.5f;
             bool clutchPressed = SafeReadFloat(_clutchCtrl, out var rc) && rc > 0.5f;
 

--- a/2026MVP/HORI_THROTTLE_BUG_RESOLUTION.md
+++ b/2026MVP/HORI_THROTTLE_BUG_RESOLUTION.md
@@ -1,0 +1,427 @@
+# HORI Truck Control System (HPC-044U) — Resolución del bug del acelerador
+
+**Fecha:** 2026-05-03
+**Tiempo total de debugging:** ~6h (4 builds Unity + 5 plans probados)
+**Resultado:** ✅ Throttle responde correctamente vía P/Invoke directo a Windows HID
+
+## TL;DR
+
+El HID parser auto-generado de **Unity 6 Input System** tiene un bug con el descriptor del HORI HPC-044U (declara dos `Slider` con HID Usage `0x36`). Unity hace alias de los dos sliders al mismo byte del input report y deja el byte del **throttle (offset 21-22) huérfano** — ningún `AxisControl` lo lee, y Unity ni siquiera emite `state events` cuando cambia.
+
+**Solución:** abrir el HID device path crudo (`\\?\hid#vid_0f0d&pid_017a&col01`) con `CreateFile`, hacer `ReadFile` en un thread background, leer los bytes 21-22 directo. Bypass total de Unity Input System para ese byte.
+
+---
+
+## 1. El problema reportado
+
+> "tengo un problema en Manejo, no detecta el acelerador del Hori truck volante. Detecta el freno y el clutch pero no el acelerador. Ya pusimos el dump en F7 pero tampoco aparece nada... pero en mi computadora Windows de prueba todo funciona."
+
+Síntomas:
+- HORI Truck Control System Wheel (HPC-044U) — wheel oficial para ETS2/ATS.
+- Brake y clutch detectados correctamente en Unity.
+- Throttle NO detectado en ningún axis (`z`, `rx`, `ry`, `rz`, `slider`, `slider1`, `slider2`).
+- Ocurre en 4 kioskos remotos productivos.
+- HORI Manager (UI propietaria) sí ve los 3 pedales bien — descarta hardware/firmware.
+- (Spoiler: tampoco funcionaba en la PC del usuario, pero al inicio creyó que sí.)
+
+## 2. Hipótesis descartadas (lo que NO era)
+
+### Hipótesis 1: HORI Device Manager activo
+**Idea:** el Manager reconfigura el HID descriptor.
+**Descartada:** mismo síntoma con/sin Manager instalado. Verificado por el usuario.
+
+### Hipótesis 2: Platform Toggle Switch en posición incorrecta
+**Idea:** algunos volantes HORI tienen un switch físico PC/console.
+**Descartada:** el HPC-044U es PC-only. El "Platform Toggle Switch" mencionado en una página de HORI venía mezclado con el manual de un modelo distinto (HPC-044E europeo o variante PS4).
+
+### Hipótesis 3: INF residual del HORI Manager corrompiendo enumeración
+**Idea:** Manager registra un INF custom; tras desinstalar queda residual.
+**Descartada:** el usuario verificó que su PC (que también tenía el problema) **nunca tuvo Manager instalado**.
+
+### Hipótesis 4: Pedal calibration al boot
+**Idea:** el wheel auto-calibra solo "L pedal y R pedal" según el manual; el throttle podría quedar sin calibrar.
+**Descartada:** HORI Manager ve los 3 pedales con valores válidos → calibración OK.
+
+### Hipótesis 5: USB hub / extensión
+**Idea:** el manual prohíbe hubs.
+**Descartada parcialmente:** brake+clutch funcionando en Unity descarta esto como causa primaria.
+
+## 3. Setup de diagnóstico
+
+### 3.1 Comunicación SSH con la PC Windows
+
+Para diagnósticos remotos sin viajar a los kioskos, se habilitó OpenSSH en la PC del usuario (Windows 11 Pro 24H2 build 26100):
+
+```powershell
+# En PowerShell admin:
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+# (NOTA: estado quedó en "InstallPending" por updates pendientes — necesitó REBOOT)
+
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+New-Item -Path "HKLM:\SOFTWARE\OpenSSH" -Force | Out-Null
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+```
+
+Llave pública SSH (ed25519) en:
+```
+$env:ProgramData\ssh\administrators_authorized_keys
+```
+
+con ACL:
+```powershell
+icacls $f /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F"
+```
+
+Conexión desde Mac:
+```bash
+ssh simul@10.0.0.235
+```
+
+**Truco para evitar quoting hell** con caracteres especiales (`&`, `|`) en comandos PowerShell sobre SSH: pasar como `-EncodedCommand` base64-UTF16:
+
+```bash
+CMD='Get-PnpDevice | Where-Object { $_.InstanceId -match "VID_0F0D" }'
+ENC=$(python3 -c "import base64,sys; print(base64.b64encode(sys.argv[1].encode('utf-16le')).decode())" "$CMD")
+ssh simul@10.0.0.235 "powershell -EncodedCommand $ENC"
+```
+
+### 3.2 Scripts de diagnóstico HID (PowerShell + P/Invoke)
+
+Tres scripts construidos durante el debugging, en `/tmp/hori-diag/`:
+
+#### `hid-dump.ps1` — enumera HID interfaces y lista capabilities
+
+Usa P/Invoke a `setupapi.dll` + `hid.dll` (`HidD_GetPreparsedData`, `HidP_GetCaps`, `HidP_GetValueCaps`, `HidP_GetButtonCaps`) para enumerar las interfaces HID del wheel y dumpear:
+- VID/PID
+- Top-level Usage Page + Usage
+- Cantidad de buttons, axes
+- Bit size de cada axis, logical/physical min/max
+
+Reveló que el HORI expone **3 HID collections** del mismo USB device:
+- `COL01` — HID-compliant game controller (29-30 byte input report)
+- `COL02` — vendor-defined (UsagePage 0xFF20, 32 bytes)
+- `COL03` — vendor-defined (UsagePage 0xFF21, 64 bytes)
+
+Solo `COL01` es lo que Unity Input System lee (es el Joystick estándar).
+
+#### `hid-poll.ps1` — captura raw input reports en stream
+
+Abre `\\?\hid#vid_0f0d&pid_017a&col01#...` con `CreateFile`, hace `ReadAsync` en loop durante 15s. Guarda timestamps + hex dump de cada report a CSV.
+
+**Procedimiento de captura controlado** (operador del kiosko sigue el cronómetro):
+- t=0..3s: nada, pedales en reposo (baseline)
+- t=3..6s: pisa **CLUTCH** a fondo y suelta
+- t=6..9s: pisa **BRAKE** a fondo y suelta
+- t=9..12s: pisa **THROTTLE** a fondo y suelta
+- t=12..15s: reposo final
+
+#### `analyze.py` — diff bytes que cambian por phase
+
+Decodifica el CSV, parsea cada report como bytes, decodifica candidate axis bytes como LE16 (little-endian unsigned 16-bit), reporta:
+- Span por phase (max - min) de cada par de bytes
+- Identifica qué bytes cambian SOLO durante una phase específica → ese byte es ese pedal
+
+**Output del analyze.py para HORI HPC-044U:**
+
+| Phase | bytes 9-10 | bytes 11-18 | **bytes 19-20** | **bytes 21-22** | **bytes 23-24** |
+|---|---|---|---|---|---|
+| clutch | 32768..32768 (centered) | 32768 (centered) | **0..65535** | 0 (no movement) | 0 (no movement) |
+| brake | 32768..32768 | 32768 | 0..65314 | 0..35310 (user touched throttle too) | **0..65346** |
+| throttle | 32768..32768 | 32768 | 0 (no movement) | **0..65535** | 0 (no movement) |
+
+**Conclusión empírica:**
+
+| Bytes (LE16) | HID Usage (declarado) | Función física | Range |
+|---|---|---|---|
+| 9-10 | X (0x30) | stick/wheel | centered (rest 32768) |
+| 11-12, 13-14, 15-16, 17-18 | Y, Z, Rx, Ry | sticks/wheel | centered |
+| **19-20** | **Slider#1 (0x36)** | **CLUTCH** | unipolar (rest 0, press 65535) |
+| **21-22** | **Slider#2 (0x36)** | **THROTTLE** | unipolar |
+| **23-24** | **Rz (0x35)** | **BRAKE** | unipolar |
+
+Los **dos sliders Usage 0x36 declarados duplicados** en el descriptor son la pieza clave del bug.
+
+## 4. Identificación del bug en Unity
+
+### Lo que Unity expone (verificado en F7 LogConsolePanel "Dump controls")
+
+```
+HORI TRUCK CONTROL SYSTEM WHEEL [HID::HORI CO.,LTD. ...]
+  AxisControl  slider    valueType=Single  value=-1  ← unipolar (rest=-1 = HID raw 0)
+  AxisControl  slider1   valueType=Single  value=-1  ← unipolar
+  AxisControl  rz        valueType=Single  value=-1  ← unipolar
+  AxisControl  ry        valueType=Single  value=0   ← centered
+  AxisControl  rx        valueType=Single  value=0   ← centered
+  AxisControl  z         valueType=Single  value=0   ← centered
+  AxisControl  stick/x   valueType=Single  value=0   ← centered
+  AxisControl  stick/y   valueType=Single  value=0   ← centered
+  ButtonControl ... (varios)
+  DpadControl   hat
+```
+
+3 axes unipolares (`slider`/`slider1`/`rz`) + 5 centered (`ry`/`rx`/`z`/`stick/x`/`stick/y`) = 8 axes. Match con HID descriptor.
+
+### Comportamiento observado al pisar pedales (en F7 INPUTS EN VIVO):
+
+| Pedal pisado | Unity axes que cambian |
+|---|---|
+| Clutch | slider/slider1/rz (en lockstep parcial) |
+| Brake | slider/slider1/rz (también en lockstep) |
+| **Throttle** | **NINGUNO** |
+
+### El bug
+
+`HidP_GetValueCaps()` reporta los 8 axes con `DataIdx` 55..62 secuenciales. Pero por los 2 sliders Usage 0x36 duplicados, el HID parser de Unity:
+- Asigna `slider` a un byte específico
+- Asigna `slider1` al **MISMO byte** (alias)
+- Asigna `rz` a otro byte
+- **El tercer byte unipolar (donde vive el throttle) queda sin AxisControl que lo lea — ORPHAN BYTE**
+
+Cuando el byte 21-22 cambia (porque el usuario pisa throttle), Unity:
+- Recibe el report HID del OS
+- Pasa por `HidP_ParseInputReport`
+- No encuentra ningún tracked usage que haya cambiado (slider/slider1 leen otro byte)
+- **No emite state event** → ningún sistema upstream se entera
+
+Esto explica todas las observaciones:
+- Brake y clutch funcionan (sus bytes están mapeados a `slider`/`slider1`/`rz` cualquiera)
+- Throttle no funciona en ningún wheel HORI HPC-044U en Unity (es bug del parser, no del wheel)
+- HORI Manager funciona porque NO usa Unity Input System (lee HID raw a su manera)
+
+## 5. Soluciones intentadas
+
+### Plan A (FAILED): Custom Unity HID Layout
+
+**Idea:** registrar un `InputControlLayout` custom para `vendorId=0x0F0D, productId=0x017A` que defina explícitamente `pedalThrottle` en byte offset 21, `pedalBrake` en 23, `pedalClutch` en 19.
+
+```csharp
+InputSystem.RegisterLayout(@"
+{
+    ""name"" : ""HoriTruckPedalsFix"",
+    ""extend"" : ""HID"",
+    ""controls"" : [
+        { ""name"" : ""pedalThrottle"", ""layout"" : ""Axis"", ""format"" : ""USHT"",
+          ""offset"" : 21,
+          ""parameters"" : ""normalize,normalizeMin=0,normalizeMax=65535,normalizeZero=0"" }
+        // + clutch + brake
+    ]
+}", matches: new InputDeviceMatcher()
+    .WithInterface("HID")
+    .WithCapability("vendorId", 0x0F0D)
+    .WithCapability("productId", 0x017A));
+```
+
+**Por qué falló:**
+1. **El layout REEMPLAZA el auto-gen layout** del device entero (codex me lo advirtió antes y caí). El nuevo layout solo tenía 3 controls — perdió todos los buttons, hat, sticks, slider/slider1/rz. El wheel quedó "decapitado".
+2. El matcher capturó **las 3 HID collections** (COL01 + COL02 + COL03), creando 3 devices "HoriTruckPedalsFix" con solo 3 controls cada uno.
+3. Aún en COL01, los offsets 19/21/23 que usé eran probablemente incorrectos — Unity strip-ea el report ID y/o reorganiza el state buffer.
+4. Resultado: nada se movía con pedales, y se rompió todo lo demás.
+
+### Plan C (FAILED): InputSystem.onEvent intercept
+
+**Idea:** suscribirse a `InputSystem.onEvent` para interceptar los `StateEvent`/`DeltaStateEvent` que Unity recibe del wheel ANTES de que el parser los procese. Leer bytes 21-22 directo del state buffer.
+
+```csharp
+unsafe void OnEvent(InputEventPtr e, InputDevice device) {
+    if (!_horiCandidates.Contains(device.deviceId)) return;
+    if (e.IsA<StateEvent>()) {
+        StateEvent* se = (StateEvent*)e.data;
+        byte* state = (byte*)se->state;
+        ushort raw = (ushort)(state[21] | (state[22] << 8));
+        Value = raw / 65535f;
+    }
+}
+```
+
+**Por qué falló:**
+
+Unity NO emite state events cuando solo cambia un byte huérfano (sin AxisControl que lo lea). Verificado: con el throttle pumping activo durante 30+ segundos, el reader capturó solo eventos donde los axes TRACKED cambiaban (jitter del wheel/sticks centered). Los bytes 21-22 nunca se vieron cambiar en el state buffer entregado a `onEvent`.
+
+Conclusión: el state buffer de Unity (post-parser) **no es un mirror fiel del raw HID report**. Unity solo propaga cambios de usages declarados.
+
+### Plan B (WORKING): P/Invoke directo a Windows HID
+
+**Idea:** abrir el HID device path crudo de Windows con `CreateFile`, hacer `ReadFile` en un thread background. El raw HID report viene tal cual del firmware del wheel — bypass total de Unity Input System.
+
+```csharp
+// Enumera HID device paths
+var paths = EnumerateHidPaths();  // SetupDi APIs
+var col01Path = paths.FirstOrDefault(p =>
+    p.ToLower().Contains("vid_0f0d&pid_017a") && p.ToLower().Contains("col01"));
+
+// Abre el device handle (SHARED — coexiste con Unity y HORI Manager)
+var handle = CreateFile(col01Path,
+    GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+    IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+
+// Background thread con ReadFile loop
+Thread t = new Thread(() => {
+    byte[] buffer = new byte[64];
+    while (_running) {
+        ReadFile(handle, buffer, (uint)buffer.Length, out uint read, IntPtr.Zero);
+        if (read >= 23) {
+            ushort raw = (ushort)(buffer[21] | (buffer[22] << 8));
+            _value = raw / 65535f;  // volatile float
+        }
+    }
+});
+t.IsBackground = true;
+t.Start();
+```
+
+**Por qué funciona:**
+- `ReadFile` sobre un HID device handle entrega el input report **completo y crudo** desde el OS. Los 30 bytes con report ID, hat, buttons, axes — todo.
+- No depende del parser HID de Unity. El bug del parser es irrelevante.
+- Verificado empíricamente: el byte 21-22 cambia 0..65535 al pisar throttle (lo confirmamos primero con `hid-poll.ps1`, luego en producción dentro de Unity).
+
+**Integración con UIInputNew:**
+
+Cross-asmdef issue: `HoriThrottleReader.cs` vive en `Assets/Custom/` (Assembly-CSharp.dll). `UIInputNew.cs` vive en `Assets/Gley/UrbanAssets/` (Gley assembly). Gley NO puede referenciar Assembly-CSharp (ciclo prohibido). Solución: **delegate injection desde Assembly-CSharp → Gley**.
+
+```csharp
+// En UIInputNew.cs (Gley):
+public static System.Func<float> HoriThrottleProvider;
+
+// En HoriThrottleReader.cs (Custom):
+[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+static void Bootstrap() {
+    // ...
+    Gley.UrbanSystem.UIInputNew.HoriThrottleProvider = () =>
+        _instance != null ? _instance.Value : 0f;
+}
+```
+
+`UIInputNew.ReadGasRawValue()` llama el provider cuando el flag `_useHoriRawGas` está set; cae al `_gasCtrl` normal cuando no.
+
+## 6. Archivos del fix
+
+### `Assets/Custom/HoriThrottleReader.cs` (nuevo)
+
+Singleton MonoBehaviour, `RuntimeInitializeOnLoadMethod(BeforeSceneLoad)`, Windows-only via `#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN`.
+
+P/Invoke a `setupapi.dll`, `hid.dll`, `kernel32.dll`. Enumera HID paths, filtra `vid_0f0d&pid_017a` + `col01`, `CreateFile`, thread background con `ReadFile` blocking loops, lee bytes 21-22 LE16 / 65535 → `Value` (volatile float).
+
+Hot-plug: `Update()` retry every 2s si el poller muere. `OnDestroy` cierra handle + Join thread. Reset `Value=0` al perder handle (codex review: evita aceleración fantasma).
+
+### `Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs`
+
+```diff
++ public const string HORI_RAW_GAS_PATH = "__HORI_RAW_HID_THROTTLE__";
++ public static System.Func<float> HoriThrottleProvider;
++ private bool _useHoriRawGas;
+
+  // En IsHORITruck(device) block de AttachToWheelDevice:
++ PlayerPrefs.SetString("G923_GasAxis", HORI_RAW_GAS_PATH);
++ PlayerPrefs.SetFloat("G923_GasRest", 0f);
++ PlayerPrefs.SetFloat("G923_GasPress", 1f);
++ _useHoriRawGas = true;
+
+  // Después del HORI block, al cargar gasPath de PlayerPrefs:
++ // Guard: si sentinel persiste pero device != HORI, invalida.
++ if (gasPath == HORI_RAW_GAS_PATH && !IsHORITruck(device)) {
++     PlayerPrefs.DeleteKey("G923_GasAxis");
++     gasPath = "z";
++ }
++ _useHoriRawGas = (gasPath == HORI_RAW_GAS_PATH);
++ _gasCtrl = _useHoriRawGas ? null : CacheControl(gasPath);
+
+  // Helper:
++ private float ReadGasRawValue() {
++     if (_useHoriRawGas) {
++         var p = HoriThrottleProvider;
++         return p != null ? p() : _gasRest;
++     }
++     return SafeReadFloatRaw(_gasCtrl, out var v) ? v : _gasRest;
++ }
+
+  // 3 sites de gas read reemplazados:
+- float gasRaw = SafeReadFloatRaw(_gasCtrl, out var rg) ? rg : _gasRest;
++ float gasRaw = ReadGasRawValue();
+```
+
+### `Assets/Custom/Menu/MenuScreenManager.cs`
+
+Phase 3 (gas) de Pantalla 2 auto-pasa para HORI con el sentinel. Discovery sigue normal para steering/brake/clutch.
+
+```csharp
+if (!throttleDone) {
+    var devForGas = TryAttachToDevice();
+    if (devForGas != null && UIInputNew.IsHORITruck(devForGas)) {
+        throttleDone = true;
+        PlayerPrefs.SetString("G923_GasAxis", UIInputNew.HORI_RAW_GAS_PATH);
+        PlayerPrefs.SetFloat("G923_GasRest", 0f);
+        PlayerPrefs.SetFloat("G923_GasPress", 1f);
+        wheelPrompt.text = "Pisa el FRENO a fondo";
+        return;
+    }
+    // Discovery normal para non-HORI...
+}
+```
+
+## 7. Garantía de no romper G923
+
+El fast-path de Logitech G923 en `MenuScreenManager` **no se tocó**. Sigue idéntico:
+- Detecta G923 → `EnsureG923PSDefaults` setea `G923_GasAxis = "z"` (PS) o `"stick/y"` (Xbox), rest=1, press=-1.
+- Marca todas las fases done, carga escena directo.
+
+En `UIInputNew`, el camino G923:
+1. `IsLogitechG923Family(device)` → `EnsureG923PSDefaults` setea `G923_GasAxis`.
+2. Load normal: `gasPath = "z"` o `"stick/y"` (no es el sentinel HORI).
+3. `_useHoriRawGas = (gasPath == HORI_RAW_GAS_PATH)` → **false**.
+4. `_gasCtrl = CacheControl(gasPath)` corre normal.
+5. `ReadGasRawValue()` cae al else branch y lee `_gasCtrl` normal vía `SafeReadFloatRaw`.
+
+**Edge case** (usuario cambia de HORI a G923 sin re-discovery): cubierto por el guard en UIInputNew que invalida el sentinel cuando el device actual no es HORI.
+
+## 8. Codex review iterations
+
+Plan se validó con codex en 4 iteraciones a lo largo del debugging:
+
+1. **Hipótesis ranking** (inicial): codex priorizó Platform Toggle Switch → boot calibration → USB hub → física → firmware. La realidad: ninguna de las 5; era bug de Unity HID parser.
+2. **Layout JSON validation** (Plan A): codex advirtió que `RegisterLayout` REEMPLAZA en vez de extender, y que necesitaba state struct completo. Caí en el warning. ✅ Decisión correcta de codex.
+3. **InputSystem.onEvent design** (Plan C): codex advirtió que podía estar enganchado a la collection equivocada (3 devices) y que faltaba manejar `DeltaStateEvent`. Apliqué ambos. La falla real fue otra: Unity no emite events para bytes huérfanos.
+4. **Sleep review final** (Plan B): codex encontró 3 issues concretos:
+   - `volatile float` para visibility cross-thread → aplicado
+   - Reset `Value=0` en unplug para evitar aceleración fantasma → aplicado
+   - Sentinel guard si device cambia de HORI a G923 → aplicado
+   - `csc.rsp -unsafe` innecesario tras refactor → removido
+
+## 9. Lecciones aprendidas
+
+1. **Unity HID parser es flaky con descriptors no estándar.** Usages duplicados, vendor collections weird, etc. Rule of thumb: si un wheel funciona en otra app pero no en Unity, sospechar primero del parser.
+2. **`InputSystem.onEvent` no es un raw HID intercept.** Solo emite cuando un control declarado cambia. Para raw, P/Invoke es la única salida.
+3. **P/Invoke a Windows HID es estable y simple.** ~150 líneas C#, sin dependencias externas. Funciona en standalone Unity Win64.
+4. **PowerShell `-EncodedCommand` resuelve el quoting hell** sobre SSH cuando hay `&` o `|` en comandos.
+5. **Cross-asmdef en Unity:** Custom → Gley está permitido, Gley → Custom no. Para inyección bidireccional, usar **static delegate** declarado en Gley y asignado desde Custom.
+6. **Codex review repetido (3-4 rounds)** atrapó issues que solo hubiera detectado en producción: alias contamination, phantom acceleration, memory ordering. Rentabilísimo.
+7. **No confiar en el primer F7 dump del usuario.** El usuario reportó que su PC funcionaba; en realidad solo brake+clutch funcionaban, throttle nunca. La verificación empírica con raw HID definió el problema.
+
+## 10. Tools de diagnóstico — referencia rápida
+
+| Tool | Path | Usado para |
+|---|---|---|
+| `hid-dump.ps1` | `/tmp/hori-diag/` | Enumerar HID interfaces + capabilities (P/Invoke a HidD/HidP APIs) |
+| `hid-poll.ps1` | `/tmp/hori-diag/` | Capturar raw HID input reports a CSV |
+| `analyze.py` | `/tmp/hori-diag/` | Diff bytes que cambian por phase de pedales |
+| `hori-diagnose.ps1` | `Manejo/2026MVP/scripts/` | Dump genérico PnP/HID/INF para diff entre PCs |
+
+## 11. Pendiente y future-proofing
+
+- **Si Unity actualiza Input System** y arregla el bug del parser HID con duplicate Slider Usages, el reader puede retirarse. Verificar:
+  ```csharp
+  // Si en F7 LogConsolePanel post-update aparece pedalThrottle moviéndose,
+  // o si slider/slider1 dejan de hacer alias, es seguro remover el bypass.
+  ```
+- **Otros wheels con 3 pedales y Slider duplicado** podrían tener el mismo bug. Si aparecen, la misma solución (P/Invoke + sentinel) generaliza fácil.
+- **FFB del HORI** está fuera del alcance de este fix. El HPC-044U sí tiene motors FFB pero el bypass solo cubre input, no output.
+
+## 12. Referencias
+
+- [HORI USA HPC-044U product page](https://stores.horiusa.com/HPC-044U)
+- [HORI HPC-044U manual (manuals.plus)](https://manuals.plus/hori/hpc-044u-force-feedback-truck-control-system-manual)
+- [Unity Input System 1.7 HID Support](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.7/manual/HID.html)
+- [Microsoft HID drivers reference](https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/)
+- [Understanding HID Report Descriptors (who-t)](http://who-t.blogspot.com/2018/12/understanding-hid-report-descriptors.html)
+- PR de la solución: [General-Kain/Manejo#127](https://github.com/General-Kain/Manejo/pull/127)

--- a/2026MVP/scripts/hori-diagnose.ps1
+++ b/2026MVP/scripts/hori-diagnose.ps1
@@ -1,0 +1,178 @@
+# HORI Truck Control System (HPC-044U) — Diagnostico de pedales en Unity
+#
+# Compara enumeracion HID/PnP/INF entre la PC del usuario (donde funciona)
+# y los kioskos remotos (donde Unity no detecta el throttle).
+#
+# Uso: copiar este archivo a la PC objetivo, click derecho > Run with PowerShell.
+# El ZIP final se guarda en el Escritorio. Mandalo por SMB o email a Miguel.
+
+$ErrorActionPreference = 'Continue'
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$reportRoot = Join-Path $env:TEMP "hori-diagnose-$stamp"
+New-Item -ItemType Directory -Force -Path $reportRoot | Out-Null
+
+Write-Host "=== HORI Truck Diagnostic ===" -ForegroundColor Cyan
+Write-Host "Computer: $env:COMPUTERNAME"
+Write-Host "User:     $env:USERNAME"
+Write-Host "Output:   $reportRoot"
+Write-Host ""
+
+function Save-Section {
+    param([string]$Name, [scriptblock]$Block)
+    $out = Join-Path $reportRoot "$Name.txt"
+    Write-Host "  -> $Name" -ForegroundColor DarkGray
+    try {
+        & $Block 2>&1 | Out-String | Set-Content -Path $out -Encoding UTF8
+    } catch {
+        "ERROR: $_" | Set-Content -Path $out
+    }
+}
+
+# 1) Version de Windows
+Save-Section 'winver' {
+    [System.Environment]::OSVersion.VersionString
+    "ComputerName: $env:COMPUTERNAME"
+    Get-ComputerInfo |
+        Select-Object WindowsProductName, WindowsVersion, WindowsBuildLabEx, OsHardwareAbstractionLayer, OsArchitecture |
+        Format-List
+}
+
+# 2) Devices HORI por VID 0F0D y por nombre
+$horiDevs = Get-PnpDevice -PresentOnly | Where-Object {
+    $_.InstanceId -match 'VID_0F0D' -or $_.FriendlyName -match 'HORI|Truck Control'
+}
+
+if (-not $horiDevs) {
+    Write-Warning "No se encontraron devices HORI. Verifica que el wheel este conectado y encendido."
+    "NO HORI DEVICES FOUND" | Set-Content (Join-Path $reportRoot 'NO_HORI_FOUND.txt')
+}
+
+Save-Section 'hori-devices' {
+    if ($horiDevs) { $horiDevs | Format-List Status, Class, FriendlyName, InstanceId, Manufacturer }
+    else { "(none)" }
+}
+
+# 3) Propiedades PnP completas de cada device HORI
+$allProps = @()
+foreach ($d in $horiDevs) {
+    $props = Get-PnpDeviceProperty -InstanceId $d.InstanceId -ErrorAction SilentlyContinue
+    $allProps += [pscustomobject]@{
+        InstanceId   = $d.InstanceId
+        FriendlyName = $d.FriendlyName
+        Class        = $d.Class
+        Status       = $d.Status
+        Manufacturer = $d.Manufacturer
+        Properties   = $props | Select-Object KeyName, Type, Data
+    }
+}
+$allProps | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $reportRoot 'hori-properties.json') -Encoding UTF8
+
+# 4) pnputil — drivers instalados (busca INF residuales de HORI)
+Save-Section 'pnputil-drivers' { pnputil /enum-drivers }
+Save-Section 'pnputil-drivers-hori-only' { pnputil /enum-drivers | Select-String -Context 0,8 -Pattern 'HORI|hpc|truck' }
+Save-Section 'pnputil-hid-devices' { pnputil /enum-devices /connected /class HIDClass }
+
+# 5) Registry exports — Enum\HID y Enum\USB para los devices HORI
+& reg export 'HKLM\SYSTEM\CurrentControlSet\Enum\HID' (Join-Path $reportRoot 'enum-hid.reg') /y *> $null
+& reg export 'HKLM\SYSTEM\CurrentControlSet\Enum\USB' (Join-Path $reportRoot 'enum-usb.reg') /y *> $null
+
+# 6) HID Report Descriptors crudos del registro (CLAVE para diagnostico)
+$hidDescriptors = @()
+Get-ChildItem 'HKLM:\SYSTEM\CurrentControlSet\Enum\HID' -Recurse -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match 'VID_0F0D' } |
+    ForEach-Object {
+        $node = $_
+        $dp = Join-Path $node.PsPath 'Device Parameters'
+        $entry = [ordered]@{
+            FullPath        = $node.Name
+            ChildName       = $node.PSChildName
+        }
+        if (Test-Path $dp) {
+            $p = Get-ItemProperty -Path $dp -ErrorAction SilentlyContinue
+            if ($p.'HidReportDescriptor') {
+                $bytes = $p.'HidReportDescriptor'
+                $entry.HidReportDescriptorHex = ($bytes | ForEach-Object { $_.ToString('X2') }) -join ' '
+                $entry.HidReportDescriptorLen = $bytes.Length
+            }
+            $entry.OtherDeviceParams = $p.PSObject.Properties |
+                Where-Object { $_.Name -notmatch '^PS' -and $_.Name -ne 'HidReportDescriptor' } |
+                ForEach-Object { @{ Name = $_.Name; Value = $_.Value } }
+        }
+        $hidDescriptors += [pscustomobject]$entry
+    }
+$hidDescriptors | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $reportRoot 'hid-descriptors.json') -Encoding UTF8
+
+# 7) USB selective suspend / power management para devices HORI
+$usbProps = @()
+foreach ($d in ($horiDevs | Where-Object { $_.Class -in @('USB','HIDClass') })) {
+    $key = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($d.InstanceId)\Device Parameters"
+    if (Test-Path $key) {
+        $kp = Get-ItemProperty -Path $key -ErrorAction SilentlyContinue
+        $usbProps += [pscustomobject]@{
+            InstanceId                       = $d.InstanceId
+            FriendlyName                     = $d.FriendlyName
+            Class                            = $d.Class
+            SelectiveSuspendEnabled          = $kp.SelectiveSuspendEnabled
+            EnhancedPowerManagementEnabled   = $kp.EnhancedPowerManagementEnabled
+            DeviceSelectiveSuspended         = $kp.DeviceSelectiveSuspended
+        }
+    }
+}
+$usbProps | ConvertTo-Json | Set-Content (Join-Path $reportRoot 'usb-power.json') -Encoding UTF8
+
+# 8) Power scheme actual
+Save-Section 'powercfg' { powercfg /q SCHEME_CURRENT }
+
+# 9) Game controllers visibles (DirectInput / joy.cpl)
+Save-Section 'game-controllers' {
+    Get-PnpDevice -PresentOnly |
+        Where-Object { $_.PNPClass -eq 'HIDClass' } |
+        Where-Object { $_.FriendlyName -match 'game|joystick|controller|wheel|HORI|Truck' -or $_.InstanceId -match 'VID_0F0D' } |
+        Format-List FriendlyName, InstanceId, Status, Manufacturer
+}
+
+# 10) Servicios HID-related
+Save-Section 'hid-services' {
+    Get-Service | Where-Object { $_.Name -match 'HID|hidserv|HidUsb|usbhub' } |
+        Format-Table Name, Status, StartType, DisplayName -AutoSize
+}
+
+# 11) Drivers HID cargados (para detectar Logitech G HUB / Hori Manager)
+Save-Section 'driverquery-hid' {
+    driverquery /v /fo TABLE | findstr /I "HID HORI Logitech racing wheel"
+}
+
+# 12) Composicion USB completa del wheel (para ver MI_xx)
+Save-Section 'usb-composition' {
+    Get-PnpDevice -PresentOnly |
+        Where-Object { $_.InstanceId -match 'VID_0F0D' } |
+        Sort-Object InstanceId |
+        Format-List InstanceId, Class, FriendlyName, Status, Service
+}
+
+# 13) DirectInput-style enumeration via WMI (Win32_PnPEntity)
+Save-Section 'wmi-pnp' {
+    Get-CimInstance Win32_PnPEntity |
+        Where-Object { $_.PNPDeviceID -match 'VID_0F0D' -or $_.Name -match 'HORI|Truck Control' } |
+        Format-List Name, PNPClass, PNPDeviceID, Manufacturer, Service, Status
+}
+
+# 14) Comprimir todo
+$zipPath = Join-Path $env:USERPROFILE "Desktop\hori-diagnose-$env:COMPUTERNAME-$stamp.zip"
+Compress-Archive -Path (Join-Path $reportRoot '*') -DestinationPath $zipPath -Force
+
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor Green
+Write-Host "  DIAGNOSTIC COMPLETE" -ForegroundColor Green
+Write-Host "==========================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "ZIP report:" -ForegroundColor Yellow
+Write-Host "  $zipPath" -ForegroundColor White
+Write-Host ""
+Write-Host "Mandalo a Miguel por:" -ForegroundColor Yellow
+Write-Host "  - Email" -ForegroundColor White
+Write-Host "  - SMB share" -ForegroundColor White
+Write-Host "  - WhatsApp" -ForegroundColor White
+Write-Host ""
+
+Read-Host "Press Enter to close"


### PR DESCRIPTION
## Resumen

El HID parser auto-generado de Unity tiene un bug con el descriptor del **HORI HPC-044U** (2 sliders Usage 0x36 duplicados). Unity hace alias \`slider\`/\`slider1\` al mismo byte y deja el byte del **throttle (21-22 del input report)** huérfano — ningún AxisControl lo lee. Por eso pisar el acelerador en este wheel no hace nada en Unity (verificado en kiosko Aramis 2026-05-03 + en PC del usuario).

**Fix**: Plan B después de descartar Plan A (custom layout) y Plan C (\`InputSystem.onEvent\` intercept — no funciona porque Unity no emite state events para bytes huérfanos). Lectura **directa del HID** vía P/Invoke a Windows, bypassando Unity Input System completamente para ese byte específico.

- new: \`Assets/Custom/HoriThrottleReader.cs\` — singleton con thread background haciendo \`ReadFile\` loops sobre \`\\\\?\\hid#vid_0f0d&pid_017a&col01\`. Lee bytes 21-22 LE16 / 65535 → \`Value\` (volatile float).
- mod: \`Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs\`:
  - Sentinel \`HORI_RAW_GAS_PATH\` + flag \`_useHoriRawGas\` + helper \`ReadGasRawValue()\`.
  - HORI block en \`AttachToWheelDevice\` setea sentinel + flag.
  - 3 sites de \`SafeReadFloatRaw(_gasCtrl)\` reemplazados con \`ReadGasRawValue()\`.
  - Cross-asmdef inject vía \`HoriThrottleProvider\` static delegate.
  - **Guard sentinel**: si el sentinel HORI quedó persistido pero el device actual NO es HORI, se invalida (evita envenenar otros wheels).
- mod: \`Assets/Custom/Menu/MenuScreenManager.cs\` — Phase 3 (gas) de Pantalla 2 auto-pasa para HORI; Discovery sigue normal para steering/brake/clutch.
- new: \`scripts/hori-diagnose.ps1\` — tool de diagnóstico PnP/HID/INF para futuras debugging sessions.

## ⚠️ Garantía de no romper G923

- **Logitech G923 fast-path en \`MenuScreenManager\` no se tocó**. Sigue idéntico — detecta G923, llama \`EnsureG923PSDefaults\`, marca todas las fases done, carga escena directo.
- En \`UIInputNew\`, el camino G923:
  1. \`IsLogitechG923Family(device)\` → \`EnsureG923PSDefaults\` setea \`G923_GasAxis = "z"\` (PS) o \`"stick/y"\` (Xbox), rest=1, press=-1.
  2. Load normal: \`gasPath = "z"\` (no es el sentinel HORI).
  3. \`_useHoriRawGas = (gasPath == HORI_RAW_GAS_PATH)\` → **false**.
  4. \`_gasCtrl = CacheControl(gasPath)\` corre normal.
  5. \`ReadGasRawValue()\` cae al else branch y lee \`_gasCtrl\` normal vía \`SafeReadFloatRaw\`.
- Edge case cubierto por el guard: si el usuario alguna vez calibró HORI y luego cambia a G923, al detectar device no-HORI con sentinel persistido, se invalida.

## Codex review aplicado

- ✅ \`volatile float\` para \`Value\` (memory ordering cross-thread).
- ✅ Reset \`Value = 0\` al fallar \`ReadFile\` (evita aceleración fantasma en unplug).
- ✅ Sentinel guard cuando \`device != HORI\`.
- ✅ \`csc.rsp -unsafe\` removido (innecesario tras refactor a SafeFileHandle/byte[]).
- ⏳ \`HoriThrottleProvider\` global delegate: aceptado (codex lo marcó como "low risk", el contrato es flojo pero funcional).

## Test plan

- [x] Build #4 con P/Invoke probado en kiosko Aramis (10.0.0.235) — throttle responde en escena de manejo (2026-05-03).
- [ ] Smoke test G923 PS (kiosko Casa Aramis con \`d603a85840752414e264d4dc47ec76db5a511135\`).
- [ ] Smoke test G923 Xbox (kiosko Demo Gobernadora 2026-04-26).
- [ ] Deploy via OTA a los 4 kioskos remotos restantes con HORI.
- [ ] Validación largo plazo: ¿el reader sobrevive sleep/hibernate de Windows? (probable — Update() retry every 2s).
- [ ] Validación hot-plug: desconectar/reconectar wheel mid-game.

## Rollback

Revert este PR desde GitHub UI o:
\`\`\`bash
git revert <merge-sha>
\`\`\`

Los 4 archivos del PR son aislados (1 nuevo + 3 modificados con cambios localizados al gas-read flow). El revert no toca nada de G923/moto/keyboard input paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)