### PR TITLE
feat(menu): Modo Práctica — 3 minutos antes del examen

### DIFF
--- a/2026MVP/Assets/Custom/ExamResultsScreen.cs
+++ b/2026MVP/Assets/Custom/ExamResultsScreen.cs
@@ -124,12 +124,16 @@ public class ExamResultsScreen : MonoBehaviour
         int totalDeducted = 0;
         for (int i = 0; i < faults.Count; i++) totalDeducted += Mathf.Abs(faults[i].points);
 
-        Color scoreColor = GetScoreColor(score);
-        string scoreLabel = GetScoreLabel(score);
+        bool isPractice = GameManager.Instance != null && GameManager.Instance.IsPracticeMode;
+        Color scoreColor = isPractice ? MenuTheme.TextPrimary : GetScoreColor(score);
+        string scoreLabel = isPractice
+            ? "Modo Práctica\nNo cuenta como examen"
+            : GetScoreLabel(score);
 
         // ── Header: 70-100% del alto de Content ──────────────────────────
-        // Título "Resultado del Examen" centrado arriba.
-        var titleObj = MenuCardBuilder.CreateText(content, "Title", "Resultado del Examen",
+        // Título distinto según modo: examen real vs práctica.
+        var titleObj = MenuCardBuilder.CreateText(content, "Title",
+            isPractice ? "Resumen de tu Práctica" : "Resultado del Examen",
             40f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Center);
         titleObj.GetComponent<RectTransform>().Set(
             new Vector2(0f, 0.91f), new Vector2(1f, 1f), new Vector2(0.5f, 0.5f),
@@ -161,7 +165,9 @@ public class ExamResultsScreen : MonoBehaviour
             Vector2.zero, Vector2.zero);
 
         var summarySubObj = MenuCardBuilder.CreateText(content, "SummarySub",
-            "Detalle de infracciones cometidas durante el examen",
+            isPractice
+                ? "Detalle de infracciones — sirve para identificar qué practicar"
+                : "Detalle de infracciones cometidas durante el examen",
             MenuTheme.CardDescSize, FontStyles.Normal, MenuTheme.TextMuted, TextAlignmentOptions.Left);
         summarySubObj.GetComponent<RectTransform>().Set(
             new Vector2(0.36f, 0.71f), new Vector2(0.98f, 0.79f), new Vector2(0.5f, 0.5f),

--- a/2026MVP/Assets/Custom/ExamTimer.cs
+++ b/2026MVP/Assets/Custom/ExamTimer.cs
@@ -50,6 +50,14 @@ public class ExamTimer : MonoBehaviour
 
     void Start()
     {
+        // Modo Práctica: 3 minutos en vez de 5, y registramos el inicio aquí
+        // (no en el menú) para que la verificación de volante y el LoadScene
+        // no inflen el tiempo reportado al backend.
+        if (GameManager.Instance != null && GameManager.Instance.IsPracticeMode)
+        {
+            examDuration = 180f;
+            GameManager.Instance.PracticeStartedAt = System.DateTime.UtcNow;
+        }
         startTime = Time.time;
         // Defer 1 frame para que MultiPantallaManager.Start() corra primero y
         // las cámaras tengan ya su targetDisplay reasignado según config.
@@ -283,8 +291,10 @@ public class ExamTimer : MonoBehaviour
         // Disparar evento
         OnExamFinished?.Invoke();
 
-        // Enviar resultados al backend
-        SendResultsToApi(finalScore);
+        // Enviar resultados al backend (bifurca por modo práctica)
+        bool isPractice = GameManager.Instance != null && GameManager.Instance.IsPracticeMode;
+        if (isPractice) SendPracticeResultsToApi(finalScore);
+        else SendResultsToApi(finalScore);
 
         // Mostrar pantalla de resultados
         ExamResultsScreen.Show(finalScore);
@@ -312,6 +322,19 @@ public class ExamTimer : MonoBehaviour
         }));
     }
 
+    void SendPracticeResultsToApi(int finalScore)
+    {
+        var faults = SimulatorApiClient.BuildFaultsFromTelemetry();
+        StartCoroutine(SimulatorApiClient.EndPracticeSession(finalScore, faults, true, (success) =>
+        {
+            if (!success)
+            {
+                Debug.LogWarning("[ExamTimer] Fallo al enviar práctica — guardando para retry");
+                SimulatorApiClient.SavePendingPracticeResult(finalScore, faults, true);
+            }
+        }));
+    }
+
     // ── Interrupción: guardar resultados parciales si el examen no terminó ──
 
     void OnApplicationQuit()
@@ -330,16 +353,24 @@ public class ExamTimer : MonoBehaviour
         if (examFinished) return;
         examFinished = true; // Primero — cerrar race window (OnDestroy + OnApplicationQuit)
 
+        ViolationDetector det = GetDetector();
+        int score = det != null ? det.totalScore : lastKnownScore;
+        var faults = SimulatorApiClient.BuildFaultsFromTelemetry();
+
+        // Modo Práctica: guardar parcial con completed=false (la práctica
+        // se cortó antes de los 3 min). Sin sessionId, el flujo del examen real
+        // no aplica.
+        if (GameManager.Instance != null && GameManager.Instance.IsPracticeMode)
+        {
+            SimulatorApiClient.SavePendingPracticeResult(score, faults, false);
+            Debug.Log($"[ExamTimer] Práctica interrumpida (score={score}, completed=false)");
+            return;
+        }
+
         string sessionId = GameManager.Instance?.SessionId;
         if (string.IsNullOrEmpty(sessionId)) return;
 
-        // Preferir el score actual del detector si sigue vivo — cierra la ventana
-        // de 1 frame entre el último Update() y la interrupción. Fallback al cache.
-        ViolationDetector det = GetDetector();
-        int score = det != null ? det.totalScore : lastKnownScore;
-
-        // Interrumpido: siempre passed=false, interrupted=true
-        var faults = SimulatorApiClient.BuildFaultsFromTelemetry();
+        // Examen real interrumpido: passed=false, interrupted=true
         SimulatorApiClient.SavePendingResult(sessionId, false, score, faults, true);
         Debug.Log($"[ExamTimer] Examen interrumpido (score={score}, interrupted=true)");
     }

--- a/2026MVP/Assets/Custom/GameManager.cs
+++ b/2026MVP/Assets/Custom/GameManager.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using System.Collections;
 
@@ -31,6 +32,15 @@ public class GameManager : MonoBehaviour
 
     /// <summary>0 = aleatorio entre 1..5; 1..5 = waypoint fijo. Default 1 (legacy).</summary>
     public int LocationId { get; set; } = 1;
+
+    // ── Modo Práctica (no cuenta como examen real) ───────────────────
+    public bool IsPracticeMode { get; set; }
+    public string PracticeId { get; set; }
+    public string PracticeVehicleType { get; set; }       // "Sedan", "Camioneta", "BusPasajeros", "CamionDCarga", "Motocicleta", "Ambulancia"
+    public string PracticeTransmission { get; set; }      // "Manual"|"Automatica"|null
+    public string PracticeWeather { get; set; }           // "Sol"|"Lluvia"|"Granizo"
+    public string PracticeSpawnLocation { get; set; }     // "1".."5"|"random"
+    public DateTime PracticeStartedAt { get; set; }       // Seteado por ExamTimer.Start() (no por el menú) para no inflar el tiempo
 
     void Awake()
     {
@@ -119,5 +129,13 @@ public class GameManager : MonoBehaviour
         LicenseType = null;
         SessionId = null;
         LocationId = 1;
+
+        IsPracticeMode = false;
+        PracticeId = null;
+        PracticeVehicleType = null;
+        PracticeTransmission = null;
+        PracticeWeather = null;
+        PracticeSpawnLocation = null;
+        PracticeStartedAt = default;
     }
 }

--- a/2026MVP/Assets/Custom/Menu/MenuBootstrap.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuBootstrap.cs
@@ -24,6 +24,10 @@ public static class MenuBootstrap
     {
         if (scene.name == "MainMenu")
         {
+            // Limpiar estado de la sesión anterior antes de armar el menú —
+            // de otro modo IsPracticeMode/Practice* quedarían persistentes y
+            // contaminarían el siguiente flujo (incluído un examen real).
+            if (GameManager.Instance != null) GameManager.Instance.ClearSession();
             SetupMenu();
         }
     }

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -36,9 +36,20 @@ public class MenuScreenManager : MonoBehaviour
     // se muestra como "SUV" (más reconocible para el público de la prueba).
     private readonly string[] variantScenes = { "Sedan", "Camioneta" };
 
+    // ── Constantes de pantallas ────────────────────────────────────────
+    // Constantes nombradas en lugar de literales 0..N — antes había hardcodes
+    // (ej. `currentScreen == 3` para admin, `GoToScreen(3)`) que rompen al
+    // insertar pantallas nuevas. Cualquier nueva pantalla suma un slot al final.
+    private const int SCREEN_QR = 0;
+    private const int SCREEN_OPTIONS = 1;
+    private const int SCREEN_WHEEL = 2;
+    private const int SCREEN_ADMIN = 3;
+    private const int SCREEN_PRACTICE = 4;
+    private const int SCREEN_COUNT = 5;
+
     // ── UI refs ────────────────────────────────────────────────────────
-    private GameObject[] screens = new GameObject[4];
-    private CanvasGroup[] screenGroups = new CanvasGroup[4];
+    private GameObject[] screens = new GameObject[SCREEN_COUNT];
+    private CanvasGroup[] screenGroups = new CanvasGroup[SCREEN_COUNT];
     private int currentScreen = -1;
     private GameObject mainTitleGo;
 
@@ -97,6 +108,33 @@ public class MenuScreenManager : MonoBehaviour
     private GameObject[] transmisionCards;
     private Image[] transmisionBorders;
     private Button continueBtn1;
+
+    // Pantalla Práctica
+    // Nombres de escena (deben coincidir EXACTO con Build Settings)
+    private static readonly string[] practiceVehicles =
+        { "Sedan", "Camioneta", "BusPasajeros", "CamionDCarga", "Motocicleta", "Ambulancia" };
+    private static readonly string[] practiceVehicleLabels =
+        { "Sedán", "SUV", "Bus", "Camión", "Moto", "Ambulancia" };
+    private static readonly string[] practiceWeatherLabels = { "Sol", "Lluvia", "Granizo" };
+    private static readonly string[] practiceSpawnLabels =
+        { "Centro", "Mercado", "Plaza", "Industrial", "Periférico", "Aleatorio" };
+    private GameObject[] practiceVehicleCards;
+    private Image[] practiceVehicleBorders;
+    private GameObject[] practiceTransmisionCards;
+    private Image[] practiceTransmisionBorders;
+    private GameObject practiceTransmisionRow;
+    private GameObject[] practiceWeatherCards;
+    private Image[] practiceWeatherBorders;
+    private GameObject[] practiceSpawnCards;
+    private Image[] practiceSpawnBorders;
+    private Button practiceContinueBtn;
+    private int selectedPracticeVehicleIdx = 0;
+    private int selectedPracticeTransmisionIdx = 0; // 0=Auto, 1=Manual
+    private int selectedPracticeWeatherIdx = 0;     // 0=Sol
+    private int selectedPracticeSpawnIdx = 5;       // 5=Aleatorio (default)
+    // D-pad pantalla práctica: 0=vehículo, 1=transmisión, 2=clima, 3=escenario, 4=continuar
+    private int practiceRow = 0;
+    private int practiceCol = 0;
 
     // Pantalla 2
     private TextMeshProUGUI wheelPrompt;
@@ -175,7 +213,7 @@ public class MenuScreenManager : MonoBehaviour
         SetupCanvas();
         ClearExistingChildren();
         BuildLayout();
-        ShowScreen(0);
+        ShowScreen(SCREEN_QR);
         StartQRSession();
 
         // Listener para invalidar cache de InputControl<float> cuando el device
@@ -297,11 +335,12 @@ public class MenuScreenManager : MonoBehaviour
         // Header
         BuildHeader();
 
-        // 4 pantallas
+        // 5 pantallas
         BuildScreen0_QR();
         BuildScreen1_Options();
         BuildScreen2_Wheel();
         BuildScreen3_Admin();
+        BuildScreen_Practice();
     }
 
     void BuildHeader()
@@ -323,88 +362,85 @@ public class MenuScreenManager : MonoBehaviour
     void BuildScreen0_QR()
     {
         GameObject screen = MenuCardBuilder.CreateScreenContainer(transform, "Screen0_QR");
-        screens[0] = screen;
-        screenGroups[0] = screen.GetComponent<CanvasGroup>();
+        screens[SCREEN_QR] = screen;
+        screenGroups[SCREEN_QR] = screen.GetComponent<CanvasGroup>();
 
-        // ── LAYOUT: 2 columnas según wireframe ──
+        // ── LAYOUT: 3 columnas iguales (QR · Código TLX · Modo Práctica) ──
+        // Anchors X: izq 0.03-0.32, centro 0.35-0.64, der 0.67-0.96.
+        // Dividers verticales en X=0.335 y X=0.665.
 
-        // Columna izquierda: QR — empieza más abajo para espacio con título
+        // ─── Columna 1: QR ───
         GameObject leftPanel = new GameObject("QRPanel");
         leftPanel.transform.SetParent(screen.transform, false);
         leftPanel.AddComponent<RectTransform>().Set(
-            new Vector2(0.06f, 0.05f), new Vector2(0.47f, 0.72f), new Vector2(0.5f, 0.5f),
+            new Vector2(0.03f, 0.05f), new Vector2(0.32f, 0.72f), new Vector2(0.5f, 0.5f),
             Vector2.zero, Vector2.zero);
 
-        // Título sección QR
         MenuCardBuilder.CreateText(leftPanel.transform, "QRTitle",
             "Escanea el QR",
-            36f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
+            32f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
             .GetComponent<RectTransform>().Set(
                 new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
                 new Vector2(0, 0), new Vector2(0, 50));
 
-        // QR grande
-        GameObject qrContainer = MenuCardBuilder.CreateQRDisplay(leftPanel.transform, new Vector2(380, 380));
+        GameObject qrContainer = MenuCardBuilder.CreateQRDisplay(leftPanel.transform, new Vector2(360, 360));
         qrContainer.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(0, 1), new Vector2(0, 1),
-            new Vector2(0, -70), new Vector2(380, 380));
+            new Vector2(0, -70), new Vector2(360, 360));
         qrImage = qrContainer.transform.Find("QRImage").GetComponent<RawImage>();
 
-        // Status debajo del QR
         statusText = MenuCardBuilder.CreateText(leftPanel.transform, "Status",
             "Esperando verificación...",
-            22f, FontStyles.Normal, MenuTheme.TextSecondary, TextAlignmentOptions.Left)
+            20f, FontStyles.Normal, MenuTheme.TextSecondary, TextAlignmentOptions.Left)
             .GetComponent<TextMeshProUGUI>();
         statusText.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
-            new Vector2(0, -465), new Vector2(0, 30));
+            new Vector2(0, -445), new Vector2(0, 30));
 
-        // Botón nuevo QR (oculto)
         newQRButton = MenuCardBuilder.CreateButton(leftPanel.transform, "Generar nuevo QR", "secondary",
-            new Vector2(300, 60), () => StartQRSession()).GetComponent<Button>();
+            new Vector2(280, 56), () => StartQRSession()).GetComponent<Button>();
         newQRButton.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(0, 1), new Vector2(0, 1),
-            new Vector2(150, -510), new Vector2(300, 60));
+            new Vector2(40, -490), new Vector2(280, 56));
         newQRButton.gameObject.SetActive(false);
 
-        // ── Divider vertical ──
-        GameObject divider = new GameObject("VerticalDivider");
-        divider.transform.SetParent(screen.transform, false);
-        divider.AddComponent<RectTransform>().Set(
-            new Vector2(0.5f, 0.10f), new Vector2(0.5f, 0.70f), new Vector2(0.5f, 0.5f),
+        // ─── Divider 1 ───
+        GameObject divider1 = new GameObject("VerticalDivider1");
+        divider1.transform.SetParent(screen.transform, false);
+        divider1.AddComponent<RectTransform>().Set(
+            new Vector2(0.335f, 0.10f), new Vector2(0.335f, 0.70f), new Vector2(0.5f, 0.5f),
             Vector2.zero, new Vector2(1, 0));
-        divider.AddComponent<Image>().color = MenuTheme.DividerColor;
+        divider1.AddComponent<Image>().color = MenuTheme.DividerColor;
 
-        // ── Columna derecha: Código manual ──
-        GameObject rightPanel = new GameObject("CodePanel");
-        rightPanel.transform.SetParent(screen.transform, false);
-        rightPanel.AddComponent<RectTransform>().Set(
-            new Vector2(0.53f, 0.05f), new Vector2(0.94f, 0.72f), new Vector2(0.5f, 0.5f),
+        // ─── Columna 2: Código TLX ───
+        GameObject centerPanel = new GameObject("CodePanel");
+        centerPanel.transform.SetParent(screen.transform, false);
+        centerPanel.AddComponent<RectTransform>().Set(
+            new Vector2(0.35f, 0.05f), new Vector2(0.64f, 0.72f), new Vector2(0.5f, 0.5f),
             Vector2.zero, Vector2.zero);
 
-        // Título sección código
-        MenuCardBuilder.CreateText(rightPanel.transform, "CodeTitle",
+        MenuCardBuilder.CreateText(centerPanel.transform, "CodeTitle",
             "Ingresa tu trámite",
-            36f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
+            32f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
             .GetComponent<RectTransform>().Set(
                 new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
                 new Vector2(0, 0), new Vector2(0, 50));
 
-        // Label "TLX-" arriba
-        MenuCardBuilder.CreateText(rightPanel.transform, "Prefix", "TLX-",
-            30f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
+        MenuCardBuilder.CreateText(centerPanel.transform, "Prefix", "TLX-",
+            28f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
             .GetComponent<RectTransform>().Set(
                 new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
-                new Vector2(0, -80), new Vector2(0, 40));
+                new Vector2(0, -75), new Vector2(0, 40));
 
-        // PIN input: 6 cajas debajo del label
-        var pinContainer = MenuCardBuilder.CreatePinInput(rightPanel.transform, 6, 70f, 12f);
+        // PIN input: 6 cajas, achicadas a 56px+10gap (360px total) para caber en columna 29% de 1920.
+        const float pinBoxSize = 56f;
+        const float pinBoxGap = 10f;
+        var pinContainer = MenuCardBuilder.CreatePinInput(centerPanel.transform, 6, pinBoxSize, pinBoxGap);
         pinContainer.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(0, 1), new Vector2(0, 1),
-            new Vector2(0, -125), new Vector2(6 * 70f + 5 * 12f, 80f));
+            new Vector2(0, -120), new Vector2(6 * pinBoxSize + 5 * pinBoxGap, 70f));
         codeInput = pinContainer.GetComponentInChildren<TMP_InputField>();
 
-        // Cachear refs para d-pad (hijos creados por CreatePinInput)
         Transform boxRow = pinContainer.transform.Find("BoxRow");
         pinDigits = new int[] { -1, -1, -1, -1, -1, -1 };
         pinDigitTexts = new TextMeshProUGUI[6];
@@ -416,7 +452,6 @@ public class MenuScreenManager : MonoBehaviour
             pinDigitTexts[i] = border.Find("Digit_" + i).GetComponent<TextMeshProUGUI>();
         }
 
-        // Sync teclado → pinDigits (coexistencia con d-pad)
         codeInput.onValueChanged.AddListener((string val) =>
         {
             for (int j = 0; j < 6; j++)
@@ -425,30 +460,69 @@ public class MenuScreenManager : MonoBehaviour
             RefreshPinVisuals();
         });
 
-        // Enter con código completo → verificar (equivalente a click en "Verificar Código")
         codeInput.onSubmit.AddListener((string val) =>
         {
             if (val != null && val.Trim().Length == 6)
                 OnVerifyCode();
             else
-                codeInput.ActivateInputField(); // mantener foco si aún faltan dígitos
+                codeInput.ActivateInputField();
         });
 
-        // Botón verificar — ancho completo, debajo del PIN
-        verifyButton = MenuCardBuilder.CreateButton(rightPanel.transform, "Verificar Código", "primary",
-            new Vector2(0, 70), () => OnVerifyCode()).GetComponent<Button>();
+        verifyButton = MenuCardBuilder.CreateButton(centerPanel.transform, "Verificar Código", "primary",
+            new Vector2(0, 64), () => OnVerifyCode()).GetComponent<Button>();
         verifyButton.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(1, 1), new Vector2(0.5f, 1),
-            new Vector2(0, -225), new Vector2(0, 70));
+            new Vector2(0, -210), new Vector2(0, 64));
 
-        // Error text
-        errorText0 = MenuCardBuilder.CreateText(rightPanel.transform, "ErrorText", "",
-            20f, FontStyles.Normal, MenuTheme.TextError, TextAlignmentOptions.Left)
+        errorText0 = MenuCardBuilder.CreateText(centerPanel.transform, "ErrorText", "",
+            18f, FontStyles.Normal, MenuTheme.TextError, TextAlignmentOptions.Left)
             .GetComponent<TextMeshProUGUI>();
         errorText0.textWrappingMode = TextWrappingModes.Normal;
         errorText0.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
-            new Vector2(0, -310), new Vector2(0, 50));
+            new Vector2(0, -290), new Vector2(0, 50));
+
+        // ─── Divider 2 ───
+        GameObject divider2 = new GameObject("VerticalDivider2");
+        divider2.transform.SetParent(screen.transform, false);
+        divider2.AddComponent<RectTransform>().Set(
+            new Vector2(0.665f, 0.10f), new Vector2(0.665f, 0.70f), new Vector2(0.5f, 0.5f),
+            Vector2.zero, new Vector2(1, 0));
+        divider2.AddComponent<Image>().color = MenuTheme.DividerColor;
+
+        // ─── Columna 3: Modo Práctica ───
+        GameObject practicePanel = new GameObject("PracticePanel");
+        practicePanel.transform.SetParent(screen.transform, false);
+        practicePanel.AddComponent<RectTransform>().Set(
+            new Vector2(0.67f, 0.05f), new Vector2(0.96f, 0.72f), new Vector2(0.5f, 0.5f),
+            Vector2.zero, Vector2.zero);
+
+        MenuCardBuilder.CreateText(practicePanel.transform, "PracticeTitle",
+            "Modo Práctica",
+            32f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Left)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
+                new Vector2(0, 0), new Vector2(0, 50));
+
+        MenuCardBuilder.CreateText(practicePanel.transform, "PracticeSubtitle",
+            "3 minutos · No cuenta como examen",
+            18f, FontStyles.Normal, MenuTheme.TextSecondary, TextAlignmentOptions.Left)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
+                new Vector2(0, -55), new Vector2(0, 30));
+
+        MenuCardBuilder.CreateText(practicePanel.transform, "PracticeBlurb",
+            "Familiarízate con el simulador antes de tu examen teórico. Elige el vehículo, el clima y un escenario y conduce libremente por 3 minutos.",
+            18f, FontStyles.Normal, MenuTheme.TextSecondary, TextAlignmentOptions.TopLeft)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
+                new Vector2(0, -110), new Vector2(0, 220));
+
+        Button practiceBtn = MenuCardBuilder.CreateButton(practicePanel.transform, "Practicar", "primary",
+            new Vector2(0, 64), () => OnPracticeMode()).GetComponent<Button>();
+        practiceBtn.GetComponent<RectTransform>().Set(
+            new Vector2(0, 1), new Vector2(1, 1), new Vector2(0.5f, 1),
+            new Vector2(0, -360), new Vector2(0, 64));
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -458,8 +532,8 @@ public class MenuScreenManager : MonoBehaviour
     void BuildScreen1_Options()
     {
         GameObject screen = MenuCardBuilder.CreateScreenContainer(transform, "Screen1_Options");
-        screens[1] = screen;
-        screenGroups[1] = screen.GetComponent<CanvasGroup>();
+        screens[SCREEN_OPTIONS] = screen;
+        screenGroups[SCREEN_OPTIONS] = screen.GetComponent<CanvasGroup>();
 
         // Área completa debajo del título
         GameObject area = new GameObject("CenterArea");
@@ -604,7 +678,7 @@ public class MenuScreenManager : MonoBehaviour
         PlayerPrefs.SetInt("TransmisionManual", selectedTransmisionIndex);
         PlayerPrefs.Save();
         Debug.Log($"[MenuScreenManager] Transmisión: {(selectedTransmisionIndex == 1 ? "Manual" : "Automática")}");
-        GoToScreen(2);
+        GoToScreen(SCREEN_WHEEL);
     }
 
     void OnVariantSelected(int idx)
@@ -634,8 +708,8 @@ public class MenuScreenManager : MonoBehaviour
     void BuildScreen2_Wheel()
     {
         GameObject screen = MenuCardBuilder.CreateScreenContainer(transform, "Screen2_Wheel");
-        screens[2] = screen;
-        screenGroups[2] = screen.GetComponent<CanvasGroup>();
+        screens[SCREEN_WHEEL] = screen;
+        screenGroups[SCREEN_WHEEL] = screen.GetComponent<CanvasGroup>();
 
         // Usar anchors amplios, centrado vertical
         GameObject area = new GameObject("CenterArea");
@@ -939,23 +1013,23 @@ public class MenuScreenManager : MonoBehaviour
         {
             case "motocicleta":
                 selectedSceneName = "Motocicleta";
-                GoToScreen(2); // Directo a verificación volante
+                GoToScreen(SCREEN_WHEEL); // Directo a verificación volante
                 break;
             case "publico":
                 selectedSceneName = "BusPasajeros";
-                GoToScreen(2);
+                GoToScreen(SCREEN_WHEEL);
                 break;
             case "carga":
                 selectedSceneName = "CamionDCarga";
-                GoToScreen(2);
+                GoToScreen(SCREEN_WHEEL);
                 break;
             case "emergencia":
                 selectedSceneName = "Ambulancia";
-                GoToScreen(2);
+                GoToScreen(SCREEN_WHEEL);
                 break;
             case "particular":
             default:
-                GoToScreen(1); // Mostrar opciones
+                GoToScreen(SCREEN_OPTIONS); // Mostrar opciones
                 break;
         }
     }
@@ -1034,13 +1108,13 @@ public class MenuScreenManager : MonoBehaviour
     void BuildScreen3_Admin()
     {
         GameObject screen = MenuCardBuilder.CreateScreenContainer(transform, "Screen3_Admin");
-        screens[3] = screen;
-        screenGroups[3] = screen.GetComponent<CanvasGroup>();
+        screens[SCREEN_ADMIN] = screen;
+        screenGroups[SCREEN_ADMIN] = screen.GetComponent<CanvasGroup>();
 
         // Botón Cerrar flotante (esquina superior derecha — fuera del Content
         // para que la layout nunca pueda recortarlo).
         GameObject closeBtn = MenuCardBuilder.CreateButton(screen.transform, "Cerrar", "primary",
-            new Vector2(140f, 50f), () => GoToScreen(0));
+            new Vector2(140f, 50f), () => GoToScreen(SCREEN_QR));
         closeBtn.GetComponent<RectTransform>().Set(
             new Vector2(1, 1), new Vector2(1, 1), new Vector2(1, 1),
             new Vector2(-30, -30), new Vector2(140, 50));
@@ -1144,6 +1218,248 @@ public class MenuScreenManager : MonoBehaviour
         StartCoroutine(AdminRefreshSimulator());
 
         LayoutRebuilder.ForceRebuildLayoutImmediate(contentRt);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // PANTALLA PRÁCTICA — Configuración del Modo Práctica (3 minutos)
+    // ════════════════════════════════════════════════════════════════════
+
+    void BuildScreen_Practice()
+    {
+        GameObject screen = MenuCardBuilder.CreateScreenContainer(transform, "Screen_Practice");
+        screens[SCREEN_PRACTICE] = screen;
+        screenGroups[SCREEN_PRACTICE] = screen.GetComponent<CanvasGroup>();
+
+        GameObject area = new GameObject("CenterArea");
+        area.transform.SetParent(screen.transform, false);
+        area.AddComponent<RectTransform>().Set(
+            new Vector2(0.05f, 0.03f), new Vector2(0.95f, 0.85f), new Vector2(0.5f, 0.5f),
+            Vector2.zero, Vector2.zero);
+
+        // ── Título (90-100%) ──
+        MenuCardBuilder.CreateText(area.transform, "Title", "Configura tu Práctica",
+            38f, FontStyles.Bold, MenuTheme.PrimaryPurple, TextAlignmentOptions.Center)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 0.92f), new Vector2(1, 1f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero);
+
+        MenuCardBuilder.CreateText(area.transform, "Subtitle",
+            "3 minutos de manejo libre · No cuenta como examen",
+            18f, FontStyles.Normal, MenuTheme.TextSecondary, TextAlignmentOptions.Center)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 0.86f), new Vector2(1, 0.92f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero);
+
+        // ── Vehículo (67-84%) ──
+        MenuCardBuilder.CreateText(area.transform, "VehicleLabel", "Tipo de vehículo",
+            22f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Center)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 0.80f), new Vector2(1, 0.84f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero);
+
+        practiceVehicleCards = new GameObject[practiceVehicles.Length];
+        practiceVehicleBorders = new Image[practiceVehicles.Length];
+        BuildPracticeRow(area.transform, "Vehicle", practiceVehicleLabels,
+            new[] { "S", "U", "B", "C", "M", "A" },
+            new string[] { "Compacto", "Familiar", "Pasajeros", "Carga", "Requiere Moto Sim", "Emergencia" },
+            0.66f, 0.79f, 0.13f, 0.01f,
+            practiceVehicleCards, practiceVehicleBorders,
+            i => OnPracticeVehicleSelected(i));
+
+        // ── Transmisión (52-64%) — visible solo si Sedan/SUV ──
+        practiceTransmisionRow = new GameObject("TransmisionRow");
+        practiceTransmisionRow.transform.SetParent(area.transform, false);
+        practiceTransmisionRow.AddComponent<RectTransform>().Set(
+            new Vector2(0, 0.52f), new Vector2(1, 0.64f), new Vector2(0.5f, 0.5f),
+            Vector2.zero, Vector2.zero);
+
+        MenuCardBuilder.CreateText(practiceTransmisionRow.transform, "TransmisionLabel", "Transmisión",
+            22f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Center)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 0.85f), new Vector2(1, 1f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero);
+
+        practiceTransmisionCards = new GameObject[2];
+        practiceTransmisionBorders = new Image[2];
+        BuildPracticeRow(practiceTransmisionRow.transform, "Transmision",
+            new[] { "Automática", "Manual" }, new[] { "A", "M" },
+            new[] { "Sin clutch", "Con clutch + H-shifter" },
+            0f, 0.85f, 0.30f, 0.04f,
+            practiceTransmisionCards, practiceTransmisionBorders,
+            i => OnPracticeTransmisionSelected(i));
+
+        // ── Clima (38-50%) ──
+        MenuCardBuilder.CreateText(area.transform, "WeatherLabel", "Condiciones",
+            22f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Center)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 0.46f), new Vector2(1, 0.50f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero);
+
+        practiceWeatherCards = new GameObject[3];
+        practiceWeatherBorders = new Image[3];
+        BuildPracticeRow(area.transform, "Weather", practiceWeatherLabels,
+            new[] { "S", "L", "G" },
+            new[] { "Día despejado", "Lluvia ligera", "Granizo" },
+            0.33f, 0.45f, 0.22f, 0.03f,
+            practiceWeatherCards, practiceWeatherBorders,
+            i => OnPracticeWeatherSelected(i));
+
+        // ── Escenario (20-32%) ──
+        MenuCardBuilder.CreateText(area.transform, "SpawnLabel", "Escenario",
+            22f, FontStyles.Bold, MenuTheme.TextPrimary, TextAlignmentOptions.Center)
+            .GetComponent<RectTransform>().Set(
+                new Vector2(0, 0.30f), new Vector2(1, 0.34f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero);
+
+        practiceSpawnCards = new GameObject[6];
+        practiceSpawnBorders = new Image[6];
+        BuildPracticeRow(area.transform, "Spawn", practiceSpawnLabels,
+            new[] { "1", "2", "3", "4", "5", "?" },
+            new string[] { "", "", "", "", "", "" },
+            0.18f, 0.29f, 0.13f, 0.01f,
+            practiceSpawnCards, practiceSpawnBorders,
+            i => OnPracticeSpawnSelected(i));
+
+        // ── Continuar (4-16%) ──
+        practiceContinueBtn = MenuCardBuilder.CreateButton(area.transform, "Iniciar Práctica", "primary",
+            new Vector2(100, 80), OnContinuePractice).GetComponent<Button>();
+        practiceContinueBtn.GetComponent<RectTransform>().Set(
+            new Vector2(0.30f, 0.04f), new Vector2(0.70f, 0.16f), new Vector2(0.5f, 0.5f),
+            Vector2.zero, Vector2.zero);
+
+        // Defaults visuales
+        OnPracticeVehicleSelected(0);
+        OnPracticeTransmisionSelected(0);
+        OnPracticeWeatherSelected(0);
+        OnPracticeSpawnSelected(5);
+    }
+
+    /// <summary>
+    /// Construye una fila horizontal de N cards iguales (helper para la pantalla práctica).
+    /// y0/y1 son anchors verticales dentro del parent (área completa o subrow).
+    /// </summary>
+    void BuildPracticeRow(Transform parent, string namePrefix, string[] titles, string[] letters,
+        string[] descs, float y0, float y1, float cardW, float gap,
+        GameObject[] outCards, Image[] outBorders, System.Action<int> onClick)
+    {
+        float totalW = cardW * titles.Length + gap * (titles.Length - 1);
+        float startX = (1f - totalW) / 2f;
+        for (int i = 0; i < titles.Length; i++)
+        {
+            int idx = i;
+            float left = startX + i * (cardW + gap);
+            GameObject card = MenuCardBuilder.CreateIconCard(parent, null,
+                titles[i], descs[i] ?? "", new Vector2(60, 60), letters[i]);
+            card.GetComponent<RectTransform>().Set(
+                new Vector2(left, y0), new Vector2(left + cardW, y1),
+                new Vector2(0.5f, 0.5f), Vector2.zero, Vector2.zero);
+            card.AddComponent<CanvasGroup>();
+
+            Button btn = card.AddComponent<Button>();
+            btn.targetGraphic = card.transform.Find("Background").GetComponent<Image>();
+            btn.onClick.AddListener(() => onClick(idx));
+            ColorBlock cb = btn.colors;
+            cb.normalColor = Color.white;
+            cb.highlightedColor = new Color(1.15f, 1.15f, 1.15f, 1f);
+            cb.pressedColor = new Color(0.9f, 0.9f, 0.9f, 1f);
+            cb.fadeDuration = 0.12f;
+            btn.colors = cb;
+
+            outCards[i] = card;
+            outBorders[i] = card.transform.Find("Border").GetComponent<Image>();
+        }
+    }
+
+    void OnPracticeVehicleSelected(int idx)
+    {
+        selectedPracticeVehicleIdx = idx;
+        UpdatePracticeRowSelection(practiceVehicleCards, practiceVehicleBorders, idx);
+        // Transmisión solo aplica a Sedan (0) y Camioneta/SUV (1).
+        bool transmisionVisible = (idx == 0 || idx == 1);
+        if (practiceTransmisionRow != null) practiceTransmisionRow.SetActive(transmisionVisible);
+    }
+
+    void OnPracticeTransmisionSelected(int idx)
+    {
+        selectedPracticeTransmisionIdx = idx;
+        UpdatePracticeRowSelection(practiceTransmisionCards, practiceTransmisionBorders, idx);
+    }
+
+    void OnPracticeWeatherSelected(int idx)
+    {
+        selectedPracticeWeatherIdx = idx;
+        UpdatePracticeRowSelection(practiceWeatherCards, practiceWeatherBorders, idx);
+    }
+
+    void OnPracticeSpawnSelected(int idx)
+    {
+        selectedPracticeSpawnIdx = idx;
+        UpdatePracticeRowSelection(practiceSpawnCards, practiceSpawnBorders, idx);
+    }
+
+    void UpdatePracticeRowSelection(GameObject[] cards, Image[] borders, int selectedIdx)
+    {
+        if (cards == null || borders == null) return;
+        for (int i = 0; i < cards.Length; i++)
+        {
+            bool sel = (i == selectedIdx);
+            borders[i].color = sel ? MenuTheme.CardBorderGold : MenuTheme.CardBorder;
+            cards[i].transform.Find("Background").GetComponent<Image>().color =
+                sel ? MenuTheme.CardSelected : MenuTheme.CardBackground;
+            if (sel)
+                StartCoroutine(MenuAnimator.ScalePunch(
+                    cards[i].GetComponent<RectTransform>(),
+                    MenuTheme.CardPunchScale, MenuTheme.CardPunchDuration));
+        }
+    }
+
+    /// <summary>Click en card "Modo Práctica" de pantalla 0 → setear contexto y abrir pantalla práctica.</summary>
+    void OnPracticeMode()
+    {
+        // Limpiar estado local del menú — StartSessionAndLoadScene() lee tramiteId/citizenName/licenseType
+        // del menu, NO de GameManager. Sin esto, una práctica heredaría el tramiteId de un examen previo.
+        tramiteId = null;
+        citizenName = "Práctica";
+        licenseType = "practica";
+
+        // Setear contexto cross-scene
+        var gm = GameManager.Instance;
+        gm.IsPracticeMode = true;
+        gm.PracticeId = System.Guid.NewGuid().ToString();
+        gm.TramiteId = null;
+        gm.SessionId = null;
+        gm.CitizenName = "Práctica";
+
+        GoToScreen(SCREEN_PRACTICE);
+    }
+
+    /// <summary>"Iniciar Práctica" → persistir selecciones y avanzar a verificación de volante.</summary>
+    void OnContinuePractice()
+    {
+        var gm = GameManager.Instance;
+        gm.PracticeVehicleType = practiceVehicles[selectedPracticeVehicleIdx];
+        bool isAuto = (selectedPracticeVehicleIdx == 0 || selectedPracticeVehicleIdx == 1);
+        gm.PracticeTransmission = isAuto
+            ? (selectedPracticeTransmisionIdx == 1 ? "Manual" : "Automatica")
+            : null;
+        gm.PracticeWeather = practiceWeatherLabels[selectedPracticeWeatherIdx];
+
+        // selectedPracticeSpawnIdx 0..4 = LocationId 1..5; 5 = LocationId 0 (random).
+        // Convención existente en SpawnLocationManager.
+        int locationId = (selectedPracticeSpawnIdx == 5) ? 0 : (selectedPracticeSpawnIdx + 1);
+        gm.LocationId = locationId;
+        gm.PracticeSpawnLocation = locationId == 0 ? "random" : locationId.ToString();
+        // PracticeStartedAt lo setea ExamTimer.Start() al cargar la escena — no aquí —
+        // para no inflar el tiempo con la verificación de volante y el LoadScene.
+
+        PlayerPrefs.SetInt("TransmisionManual", selectedPracticeTransmisionIdx);
+        PlayerPrefs.SetInt("Clima", selectedPracticeWeatherIdx);
+        // Mirror al PlayerPref legacy `Cargolluvia` (LogConsolePanel/LogUploader lo leen).
+        PlayerPrefs.SetInt("Cargolluvia", selectedPracticeWeatherIdx == 1 ? 1 : 0);
+        PlayerPrefs.Save();
+
+        selectedSceneName = practiceVehicles[selectedPracticeVehicleIdx];
+        GoToScreen(SCREEN_WHEEL);
     }
 
     // ── Admin UI Helpers ─────────────────────────────────────────────
@@ -1253,7 +1569,7 @@ public class MenuScreenManager : MonoBehaviour
         StartCoroutine(AdminRegisterBackend(data));
 
         Debug.Log("[Admin] Configuracion guardada");
-        GoToScreen(0);
+        GoToScreen(SCREEN_QR);
     }
 
     IEnumerator AdminRegisterBackend(SimulatorConfig.ConfigData data)
@@ -1323,7 +1639,7 @@ public class MenuScreenManager : MonoBehaviour
     }
 
     /// <summary>Llamado desde AdminPanel.cs cuando F10 abre el admin.</summary>
-    public void NavigateToAdmin() => GoToScreen(3);
+    public void NavigateToAdmin() => GoToScreen(SCREEN_ADMIN);
 
     [System.Serializable]
     private class AdminRegisterRequest
@@ -1584,19 +1900,21 @@ public class MenuScreenManager : MonoBehaviour
 
     void Update()
     {
-        if (currentScreen == 3 && Keyboard.current != null
+        if (currentScreen == SCREEN_ADMIN && Keyboard.current != null
             && Keyboard.current.escapeKey.wasPressedThisFrame)
         {
-            GoToScreen(0);
+            GoToScreen(SCREEN_QR);
             return;
         }
 
-        if (currentScreen == 0)
+        if (currentScreen == SCREEN_QR)
             UpdatePinDpad();
-        else if (currentScreen == 1)
+        else if (currentScreen == SCREEN_OPTIONS)
             UpdateOptionsDpad();
+        else if (currentScreen == SCREEN_PRACTICE)
+            UpdatePracticeDpad();
 
-        if (currentScreen != 2) return;
+        if (currentScreen != SCREEN_WHEEL) return;
 
         // Leer input (dispara detección+cacheo de device/pedales) antes de pintar debug
         float steer = ReadSteerInput();
@@ -2461,6 +2779,116 @@ public class MenuScreenManager : MonoBehaviour
                 img.color = MenuTheme.ButtonPrimary;
                 if (txt != null) txt.color = MenuTheme.ButtonPrimaryText;
             }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // D-PAD PANTALLA PRÁCTICA
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Navegación d-pad para la pantalla de configuración de práctica.
+    /// Filas: 0=vehículo, 1=transmisión (skip si no aplica), 2=clima, 3=escenario, 4=continuar.
+    /// </summary>
+    void UpdatePracticeDpad()
+    {
+        if (hatUp == null) ReadSteerInput();
+        if (hatUp == null) return;
+
+        float dt = Time.unscaledDeltaTime;
+        bool up    = DpadRepeat(hatUp,    ref dpadUpT,    ref dpadUpR,    dt);
+        bool down  = DpadRepeat(hatDown,  ref dpadDownT,  ref dpadDownR,  dt);
+        bool left  = DpadRepeat(hatLeft,  ref dpadLeftT,  ref dpadLeftR,  dt);
+        bool right = DpadRepeat(hatRight, ref dpadRightT, ref dpadRightR, dt);
+
+        bool transmisionVisible = (selectedPracticeVehicleIdx == 0 || selectedPracticeVehicleIdx == 1);
+
+        bool confirmPressed = (SafeReadFloat(circleBtn, out var ccv) && ccv > 0.5f) ||
+                              (SafeReadFloat(enterBtn,  out var cev) && cev > 0.5f);
+        if (confirmPressed)
+        {
+            if (!confirmBtnHeld)
+            {
+                confirmBtnHeld = true;
+                if (practiceRow == 0) OnPracticeVehicleSelected(practiceCol);
+                else if (practiceRow == 1 && transmisionVisible) OnPracticeTransmisionSelected(practiceCol);
+                else if (practiceRow == 2) OnPracticeWeatherSelected(practiceCol);
+                else if (practiceRow == 3) OnPracticeSpawnSelected(practiceCol);
+                else if (practiceRow == 4) OnContinuePractice();
+                RefreshPracticeVisuals();
+            }
+        }
+        else confirmBtnHeld = false;
+
+        if (!up && !down && !left && !right) return;
+
+        // Determinar maxCol según fila actual.
+        int maxCol = PracticeMaxColForRow(practiceRow, transmisionVisible);
+
+        if (up && practiceRow > 0)
+        {
+            practiceRow--;
+            // Saltar fila transmisión cuando no aplica (vehículo distinto a Sedan/SUV).
+            if (practiceRow == 1 && !transmisionVisible) practiceRow = 0;
+            maxCol = PracticeMaxColForRow(practiceRow, transmisionVisible);
+            practiceCol = Mathf.Min(practiceCol, maxCol);
+        }
+        else if (down && practiceRow < 4)
+        {
+            practiceRow++;
+            if (practiceRow == 1 && !transmisionVisible) practiceRow = 2;
+            maxCol = PracticeMaxColForRow(practiceRow, transmisionVisible);
+            practiceCol = Mathf.Min(practiceCol, maxCol);
+        }
+        else if (left && practiceCol > 0) practiceCol--;
+        else if (right && practiceCol < maxCol) practiceCol++;
+
+        RefreshPracticeVisuals();
+    }
+
+    int PracticeMaxColForRow(int row, bool transmisionVisible)
+    {
+        switch (row)
+        {
+            case 0: return practiceVehicles.Length - 1;       // 5 (6 cards)
+            case 1: return transmisionVisible ? 1 : 0;         // 1 si visible
+            case 2: return practiceWeatherLabels.Length - 1;   // 2 (3 cards)
+            case 3: return practiceSpawnLabels.Length - 1;     // 5 (6 cards)
+            case 4: return 0;                                   // botón único
+            default: return 0;
+        }
+    }
+
+    void RefreshPracticeVisuals()
+    {
+        bool transmisionVisible = (selectedPracticeVehicleIdx == 0 || selectedPracticeVehicleIdx == 1);
+        RefreshPracticeRow(practiceVehicleCards, practiceVehicleBorders, 0, selectedPracticeVehicleIdx);
+        if (transmisionVisible)
+            RefreshPracticeRow(practiceTransmisionCards, practiceTransmisionBorders, 1, selectedPracticeTransmisionIdx);
+        RefreshPracticeRow(practiceWeatherCards, practiceWeatherBorders, 2, selectedPracticeWeatherIdx);
+        RefreshPracticeRow(practiceSpawnCards, practiceSpawnBorders, 3, selectedPracticeSpawnIdx);
+
+        if (practiceContinueBtn != null)
+        {
+            Image img = practiceContinueBtn.GetComponent<Image>();
+            TextMeshProUGUI txt = practiceContinueBtn.GetComponentInChildren<TextMeshProUGUI>();
+            bool focused = (practiceRow == 4);
+            if (img != null) img.color = focused ? MenuTheme.Gold : MenuTheme.ButtonPrimary;
+            if (txt != null) txt.color = focused ? MenuTheme.TextPrimary : MenuTheme.ButtonPrimaryText;
+        }
+    }
+
+    void RefreshPracticeRow(GameObject[] cards, Image[] borders, int row, int selectedIdx)
+    {
+        if (cards == null || borders == null) return;
+        for (int i = 0; i < cards.Length; i++)
+        {
+            bool focused = (practiceRow == row && practiceCol == i);
+            bool selected = (i == selectedIdx);
+            borders[i].color = focused ? MenuTheme.Gold :
+                (selected ? MenuTheme.CardBorderGold : MenuTheme.CardBorder);
+            cards[i].transform.Find("Background").GetComponent<Image>().color =
+                selected ? MenuTheme.CardSelected : MenuTheme.CardBackground;
         }
     }
 

--- a/2026MVP/Assets/Custom/SimulatorApiClient.cs
+++ b/2026MVP/Assets/Custom/SimulatorApiClient.cs
@@ -59,17 +59,52 @@ public static class SimulatorApiClient
         public string sessionId;
     }
 
+    // ── Modo Práctica ───────────────────────────────────────────────
+
+    [System.Serializable]
+    public class EndPracticeRequest
+    {
+        public string practiceId;
+        public string pcId;
+        public string vehicleType;
+        public string transmission;     // nullable — "" en JSON cuando no aplica
+        public string weather;
+        public string spawnLocation;
+        public string startedAt;        // ISO 8601 UTC
+        public string completedAt;      // ISO 8601 UTC
+        public int durationSeconds;
+        public int score;
+        public SessionFault[] faults;
+        public bool completed;
+    }
+
     // ── Resultado pendiente (para retry offline) ─────────────────────
 
     [System.Serializable]
     public class PendingResult
     {
-        public string sessionId;
-        public bool passed;
+        // Discriminador: "exam" (default — sesión real con sessionId) o "practice".
+        // Antiguos archivos sin kind se cargan como "exam" gracias a JsonUtility.
+        public string kind;
+        // Comunes a ambos
         public int score;
         public SessionFault[] faults;
         public string savedAt;
+        // Sólo kind=="exam"
+        public string sessionId;
+        public bool passed;
         public bool interrupted;
+        // Sólo kind=="practice"
+        public string practiceId;
+        public string pcId;
+        public string vehicleType;
+        public string transmission;
+        public string weather;
+        public string spawnLocation;
+        public string startedAt;
+        public string completedAt;
+        public int durationSeconds;
+        public bool completed;
     }
 
     [System.Serializable]
@@ -176,6 +211,70 @@ public static class SimulatorApiClient
         }
     }
 
+    // ── API: Enviar resultados de Práctica ───────────────────────────
+
+    /// <summary>
+    /// POST /simulator/practice-results — envía resultados de modo práctica.
+    /// Lee identidad y configuración de GameManager.Instance.
+    /// completed=true cuando los 3 min terminaron normales; false si interrumpido.
+    /// onComplete recibe true si fue exitoso, false si falló.
+    /// </summary>
+    public static IEnumerator EndPracticeSession(int finalScore, SessionFault[] faults,
+        bool completed, System.Action<bool> onComplete)
+    {
+        string url = $"{BaseUrl}/simulator/practice-results";
+        var gm = GameManager.Instance;
+        var config = SimulatorConfig.Instance?.data;
+
+        int duration = completed ? 180 : 0;
+        if (gm != null && gm.PracticeStartedAt != default(System.DateTime))
+        {
+            duration = Mathf.Max(0,
+                Mathf.RoundToInt((float)(System.DateTime.UtcNow - gm.PracticeStartedAt).TotalSeconds));
+        }
+
+        var requestBody = new EndPracticeRequest
+        {
+            practiceId = gm?.PracticeId ?? "",
+            pcId = config?.pcId ?? "",
+            vehicleType = gm?.PracticeVehicleType ?? "",
+            transmission = gm?.PracticeTransmission ?? "",
+            weather = gm?.PracticeWeather ?? "Sol",
+            spawnLocation = gm?.PracticeSpawnLocation ?? "random",
+            startedAt = (gm?.PracticeStartedAt ?? System.DateTime.UtcNow).ToString("o"),
+            completedAt = System.DateTime.UtcNow.ToString("o"),
+            durationSeconds = completed ? 180 : duration,
+            score = finalScore,
+            faults = faults,
+            completed = completed,
+        };
+
+        string json = JsonUtility.ToJson(requestBody);
+        Debug.Log($"[SimulatorAPI] POST {url} score={finalScore} vehicle={requestBody.vehicleType} completed={completed}");
+
+        using (var request = new UnityWebRequest(url, "POST"))
+        {
+            byte[] bodyRaw = System.Text.Encoding.UTF8.GetBytes(json);
+            request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.timeout = TIMEOUT_SECONDS;
+
+            yield return request.SendWebRequest();
+
+            if (request.result == UnityWebRequest.Result.Success)
+            {
+                Debug.Log($"[SimulatorAPI] Práctica enviada exitosamente ({requestBody.practiceId})");
+                onComplete?.Invoke(true);
+            }
+            else
+            {
+                Debug.LogWarning($"[SimulatorAPI] Error enviando práctica: {request.error} ({request.responseCode})");
+                onComplete?.Invoke(false);
+            }
+        }
+    }
+
     // ── Mapeo de telemetría a faults ─────────────────────────────────
 
     /// <summary>
@@ -272,6 +371,7 @@ public static class SimulatorApiClient
         var list = LoadPendingResults();
         list.results.Add(new PendingResult
         {
+            kind = "exam",
             sessionId = sessionId,
             passed = passed,
             score = score,
@@ -284,6 +384,43 @@ public static class SimulatorApiClient
         File.WriteAllText(PendingPath, json);
         cachedPendingCount = list.results.Count;
         Debug.Log($"[SimulatorAPI] Resultado pendiente guardado ({cachedPendingCount} total)");
+    }
+
+    /// <summary>Guarda una práctica fallida para retry posterior.</summary>
+    public static void SavePendingPracticeResult(int score, SessionFault[] faults, bool completed)
+    {
+        var gm = GameManager.Instance;
+        var config = SimulatorConfig.Instance?.data;
+        int duration = completed ? 180 : 0;
+        if (gm != null && gm.PracticeStartedAt != default(System.DateTime))
+        {
+            duration = Mathf.Max(0,
+                Mathf.RoundToInt((float)(System.DateTime.UtcNow - gm.PracticeStartedAt).TotalSeconds));
+        }
+
+        var list = LoadPendingResults();
+        list.results.Add(new PendingResult
+        {
+            kind = "practice",
+            score = score,
+            faults = faults,
+            savedAt = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+            practiceId = gm?.PracticeId ?? System.Guid.NewGuid().ToString(),
+            pcId = config?.pcId ?? "",
+            vehicleType = gm?.PracticeVehicleType ?? "",
+            transmission = gm?.PracticeTransmission ?? "",
+            weather = gm?.PracticeWeather ?? "Sol",
+            spawnLocation = gm?.PracticeSpawnLocation ?? "random",
+            startedAt = (gm?.PracticeStartedAt ?? System.DateTime.UtcNow).ToString("o"),
+            completedAt = System.DateTime.UtcNow.ToString("o"),
+            durationSeconds = completed ? 180 : duration,
+            completed = completed,
+        });
+
+        string json = JsonUtility.ToJson(list, true);
+        File.WriteAllText(PendingPath, json);
+        cachedPendingCount = list.results.Count;
+        Debug.Log($"[SimulatorAPI] Práctica pendiente guardada ({cachedPendingCount} total)");
     }
 
     public static PendingResultsList LoadPendingResults()
@@ -322,13 +459,20 @@ public static class SimulatorApiClient
         foreach (var pending in list.results)
         {
             bool success = false;
-            yield return EndSession(pending.sessionId, pending.passed, pending.score,
-                pending.faults, pending.interrupted, (ok) => success = ok);
-
-            if (!success)
-                remaining.Add(pending);
+            // Discriminador kind: "exam" (default cuando vacío, archivos antiguos) o "practice".
+            if (pending.kind == "practice")
+            {
+                yield return EndPracticeSessionFromPending(pending, (ok) => success = ok);
+                if (success) Debug.Log($"[SimulatorAPI] Práctica pendiente {pending.practiceId} enviada");
+            }
             else
-                Debug.Log($"[SimulatorAPI] Resultado pendiente {pending.sessionId} enviado");
+            {
+                yield return EndSession(pending.sessionId, pending.passed, pending.score,
+                    pending.faults, pending.interrupted, (ok) => success = ok);
+                if (success) Debug.Log($"[SimulatorAPI] Resultado pendiente {pending.sessionId} enviado");
+            }
+
+            if (!success) remaining.Add(pending);
         }
 
         if (remaining.Count == 0)
@@ -342,6 +486,42 @@ public static class SimulatorApiClient
             File.WriteAllText(PendingPath, JsonUtility.ToJson(newList, true));
             cachedPendingCount = remaining.Count;
             Debug.Log($"[SimulatorAPI] Quedan {remaining.Count} resultados pendientes");
+        }
+    }
+
+    /// <summary>
+    /// Reintenta una práctica pendiente leyendo todos los datos del PendingResult
+    /// (no depende de GameManager.Instance, que en este punto ya se reseteó).
+    /// </summary>
+    private static IEnumerator EndPracticeSessionFromPending(PendingResult p, System.Action<bool> onComplete)
+    {
+        string url = $"{BaseUrl}/simulator/practice-results";
+        var requestBody = new EndPracticeRequest
+        {
+            practiceId = p.practiceId,
+            pcId = p.pcId,
+            vehicleType = p.vehicleType,
+            transmission = p.transmission ?? "",
+            weather = p.weather,
+            spawnLocation = p.spawnLocation,
+            startedAt = p.startedAt,
+            completedAt = p.completedAt,
+            durationSeconds = p.durationSeconds,
+            score = p.score,
+            faults = p.faults,
+            completed = p.completed,
+        };
+        string json = JsonUtility.ToJson(requestBody);
+
+        using (var request = new UnityWebRequest(url, "POST"))
+        {
+            byte[] bodyRaw = System.Text.Encoding.UTF8.GetBytes(json);
+            request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.timeout = TIMEOUT_SECONDS;
+            yield return request.SendWebRequest();
+            onComplete?.Invoke(request.result == UnityWebRequest.Result.Success);
         }
     }
 


### PR DESCRIPTION
## Summary

Agrega una tercera opción "Modo Práctica" en la pantalla de inicio del simulador para que el ciudadano se familiarice con los controles antes de su examen teórico. La práctica dura 3 minutos, es libre (vehículo / clima / escenario configurables), tiene todas las dinámicas activas (infracciones, FFB, cristal roto) pero **no cuenta como examen** — los resultados van a un endpoint dedicado en backend (licencias-backend#30).

PR2 de 3 (este es Unity). Backend: licencias-backend#30. Portal admin: PR3.

### Cambios principales

**Pantalla 0 — 3 columnas iguales** (antes 2 columnas):
- Escanea QR · Ingresa código TLX · **Modo Práctica**
- PIN achicado de 70px+12gap a 56px+10gap para caber en columna 29% de 1920

**Pantalla nueva (índice 4) — `BuildScreen_Practice`**:
- 4 selectores con cards: vehículo (6), transmisión (2, solo Sedan/SUV), clima (3), escenario (6: 5 ubicaciones + Aleatorio)
- `OnPracticeMode()` desde card de pantalla 0 → limpia estado local + setea `IsPracticeMode=true` + abre Pantalla 4
- `OnContinuePractice()` → persiste selecciones a `GameManager` y `PlayerPrefs`, pasa a verificación de volante (Pantalla 2)
- `UpdatePracticeDpad()` para nav G923 (5 filas con skip de transmisión cuando no aplica)

**ExamTimer**:
- En modo práctica: `examDuration = 180f` y captura `PracticeStartedAt = UtcNow` en `Start()` (no en el menú — evita inflar el tiempo con verificación de volante + LoadScene)
- `EndExam()` bifurca: práctica → `SendPracticeResultsToApi()`, examen → `SendResultsToApi()` (sin cambios)
- `SavePartialIfNeeded()` extendido para guardar parcial de práctica con `completed=false`

**SimulatorApiClient**:
- `EndPracticeSession(score, faults, completed, callback)` → POST `/simulator/practice-results`
- `SavePendingPracticeResult(...)` para retry offline
- `RetryPendingResults` (existente) ahora despacha por `kind: "exam"|"practice"`. Archivos antiguos en disco se cargan como `"exam"` (compat).

**ExamResultsScreen**:
- En modo práctica muestra "Resumen de tu Práctica" + label "Modo Práctica · No cuenta como examen" (en vez de Apto/No Apto)
- Score y tabla de infracciones se muestran igual (educativo)
- Countdown a MainMenu sin cambios

### Refactor preventivo (recomendación de Codex)

Codex revisó el plan e identificó tres bugs latentes que arreglo aquí:

1. **Constantes nombradas para pantallas** — antes había hardcodes (`NavigateToAdmin => GoToScreen(3)` línea 1326, `currentScreen == 3` línea 1587) que rompían al insertar pantalla nueva. Ahora `SCREEN_QR/OPTIONS/WHEEL/ADMIN/PRACTICE` con admin todavía en 3, práctica en 4.

2. **`MenuBootstrap` invoca `ClearSession()` al cargar MainMenu** — `ClearSession()` existía pero NO se llamaba en ningún lado. Sin esto, `IsPracticeMode=true` quedaría persistente y contaminaría el siguiente flujo (incluyendo un examen real).

3. **`StartSessionAndLoadScene` lee `tramiteId` LOCAL del menú**, no `GameManager.TramiteId`. `OnPracticeMode()` ahora limpia tanto el local como el GameManager — sino una práctica heredaría el `tramiteId` de un examen previo.

## Test plan

### Editor Unity (manual)
- [ ] **Regresión examen real (QR)**: escanear → particular → Pantalla 1 → calibrar volante → escena → POST a `/simulator/sessions/{id}/results` (no al endpoint nuevo)
- [ ] **Regresión examen real (código TLX)**: ingresar `TLX-XXXXXX` real → mismo flujo que QR
- [ ] **Regresión demo code `000010`**: 0000=particular, 1=lluvia, 0=spawn random → escena Sedan con lluvia
- [ ] **Práctica completa**: tarjeta Práctica → Sedán + Auto + Lluvia + escenario 3 → calibrar volante → escena con lluvia + spawn 3 + timer 3:00
- [ ] **Timer baja a 0:00** en 3 min y muestra `ExamResultsScreen` con header "Resumen de tu Práctica" + label "Modo Práctica · No cuenta como examen"
- [ ] **Network tab**: POST único a `/simulator/practice-results` (200 OK), NO hay POST a `/simulator/sessions/end`
- [ ] **Vuelve automático a MainMenu** tras countdown
- [ ] **Volver a MainMenu** y luego intentar QR → `IsPracticeMode` está limpio (no contamina al siguiente ciudadano)

### Resiliencia offline
- [ ] Práctica con WiFi cortado al final → log "Práctica pendiente guardada"
- [ ] Reconectar WiFi → reabrir simulador → log "Práctica pendiente {id} enviada" + POST exitoso

### Nav d-pad G923
- [ ] Pantalla 0: d-pad navega entre QR / Código / Modo Práctica
- [ ] Pantalla 4 práctica: d-pad navega vehículo → clima → escenario → continuar (transmisión skip si Bus/Camión/Moto/Ambulancia)

### Vehículos especiales
- [ ] Moto en práctica: card visible, mensaje "Requiere Moto Sim" como descripción (no se gating dinámicamente — el operador sabe si simbt001 está conectado)
- [ ] Camión: HORI Truck wheel funciona en escena CamionDCarga

### Build de testing (después de PR1 desplegado)
- [ ] `publish-unity-build 1.3.0-rc1` → deploy SOLO a SIM-008 (`d603a85840752414e264d4dc47ec76db5a511135`). No tocar productivos.

## Depends on

- Backend del endpoint `/simulator/practice-results`: SimuladoresTlax/licencias-backend#30 (debe estar deployado a stage antes de probar PR2 end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)