### PR TITLE
fix(menu): alinear botón Practicar con Verificar Código

### DIFF
--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -511,18 +511,24 @@ public class MenuScreenManager : MonoBehaviour
                 new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
                 new Vector2(0, -55), new Vector2(0, 30));
 
-        MenuCardBuilder.CreateText(practicePanel.transform, "PracticeBlurb",
-            "Familiarízate con el simulador antes de tu examen teórico. Elige el vehículo, el clima y un escenario y conduce libremente por 3 minutos.",
+        // Blurb corto que cabe en 2 líneas — alineado al área entre el subtítulo
+        // y el botón. textWrappingMode=Normal para que rompa líneas en vez de truncar.
+        var blurb = MenuCardBuilder.CreateText(practicePanel.transform, "PracticeBlurb",
+            "Familiarízate con el simulador antes de tu examen. Elige vehículo, clima y escenario.",
             18f, FontStyles.Normal, MenuTheme.TextSecondary, TextAlignmentOptions.TopLeft)
-            .GetComponent<RectTransform>().Set(
-                new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
-                new Vector2(0, -110), new Vector2(0, 220));
+            .GetComponent<TextMeshProUGUI>();
+        blurb.textWrappingMode = TextWrappingModes.Normal;
+        blurb.GetComponent<RectTransform>().Set(
+            new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, 1),
+            new Vector2(0, -110), new Vector2(0, 90));
 
+        // Botón "Practicar" alineado al mismo Y que "Verificar Código" (y=-210)
+        // para que las dos CTAs primarias queden en la misma fila visual.
         Button practiceBtn = MenuCardBuilder.CreateButton(practicePanel.transform, "Practicar", "primary",
             new Vector2(0, 64), () => OnPracticeMode()).GetComponent<Button>();
         practiceBtn.GetComponent<RectTransform>().Set(
             new Vector2(0, 1), new Vector2(1, 1), new Vector2(0.5f, 1),
-            new Vector2(0, -360), new Vector2(0, 64));
+            new Vector2(0, -210), new Vector2(0, 64));
     }
 
     // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem

En pantalla 0 (3 columnas) el botón "Practicar" quedaba mucho más abajo que "Verificar Código" porque el blurb de práctica era muy largo (220px) y además se truncaba sin word-wrap.

## Fix

- Botón "Practicar" sube de `y=-360` a `y=-210` (mismo nivel que "Verificar Código")
- Blurb baja de 220px a 90px (espacio justo para 2 líneas de 18pt)
- Texto acortado: "Familiarízate con el simulador antes de tu examen. Elige vehículo, clima y escenario."
- `textWrappingMode = Normal` explícito para que rompa líneas en vez de truncar

## Verificación

Probar en editor Unity con MainMenu — los 2 botones primarios (Verificar y Practicar) deben quedar en la misma fila visual; el blurb debe verse en 2 líneas sin truncamiento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)