### PR TITLE
fix(practice): retry pendientes al volver al menú + no filtrar transmisión

### DIFF
--- a/2026MVP/Assets/Custom/Menu/MenuBootstrap.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuBootstrap.cs
@@ -27,7 +27,14 @@ public static class MenuBootstrap
             // Limpiar estado de la sesión anterior antes de armar el menú —
             // de otro modo IsPracticeMode/Practice* quedarían persistentes y
             // contaminarían el siguiente flujo (incluído un examen real).
-            if (GameManager.Instance != null) GameManager.Instance.ClearSession();
+            if (GameManager.Instance != null)
+            {
+                GameManager.Instance.ClearSession();
+                // Reintentar resultados pendientes cada vez que se vuelve al menú —
+                // no solo al boot inicial. En kioskos con red intermitente, esto evita
+                // que un resultado fallido quede pegado hasta el próximo reinicio.
+                GameManager.Instance.StartCoroutine(SimulatorApiClient.RetryPendingResults());
+            }
             SetupMenu();
         }
     }

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -1499,7 +1499,11 @@ public class MenuScreenManager : MonoBehaviour
         // PracticeStartedAt lo setea ExamTimer.Start() al cargar la escena — no aquí —
         // para no inflar el tiempo con la verificación de volante y el LoadScene.
 
-        PlayerPrefs.SetInt("TransmisionManual", selectedPracticeTransmisionIdx);
+        // Solo persistir TransmisionManual cuando el vehículo expone esa elección
+        // (Sedan/SUV). Para Bus/Camión/Moto/Ambulancia forzamos Automática para que
+        // la verificación de volante no requiera clutch por una elección oculta del
+        // usuario en una práctica anterior con Sedan.
+        PlayerPrefs.SetInt("TransmisionManual", isAuto ? selectedPracticeTransmisionIdx : 0);
         PlayerPrefs.SetInt("Clima", selectedPracticeWeatherIdx);
         // Mirror al PlayerPref legacy `Cargolluvia` (LogConsolePanel/LogUploader lo leen).
         PlayerPrefs.SetInt("Cargolluvia", selectedPracticeWeatherIdx == 1 ? 1 : 0);


### PR DESCRIPTION
Fixes from codex review post-merge.

## 1. Retry de pendientes al volver a MainMenu

`GameManager.Start()` dispara `RetryPendingResults` solo una vez al boot del binario, y como `GameManager` tiene `DontDestroyOnLoad` no se reejecuta. Si una práctica falla por red intermitente se guarda en disk pero no se reintenta hasta el próximo reboot.

Ahora `MenuBootstrap.OnSceneLoadedCallback` dispara `RetryPendingResults` cada vez que se carga MainMenu — útil para kioskos con red flaky.

## 2. PlayerPrefs["TransmisionManual"] contaminado

En Sedan/SUV el usuario elige Manual/Automática. Para Bus/Camión/Moto/Ambulancia la sección está oculta pero antes seguíamos persistiendo el pref con el último valor (potencialmente Manual). La verificación de volante de la siguiente sesión podía requerir clutch por elección invisible.

Ahora persistimos `TransmisionManual = 0` (Automática) cuando el vehículo no expone la sección.

🤖 Generated with [Claude Code](https://claude.com/claude-code)