### PR TITLE
fix(exam): reprobar si distancia recorrida < umbral mínimo

### DIFF
--- a/2026MVP/Assets/Custom/ExamResultsScreen.cs
+++ b/2026MVP/Assets/Custom/ExamResultsScreen.cs
@@ -15,13 +15,17 @@ using System.Collections.Generic;
 public class ExamResultsScreen : MonoBehaviour
 {
     private int score;
+    private int distanceMeters;
+    private bool insufficientMovement;
     private TextMeshProUGUI countdownText;
     private const float AUTO_RETURN_SECONDS = 45f;
 
     /// <summary>
     /// Entry point estático — crea el overlay de resultados.
+    /// `insufficientMovement=true` fuerza la etiqueta "NO APTO — Examen inválido
+    /// por inactividad" sin importar el score (alumno se quedó parado).
     /// </summary>
-    public static void Show(int finalScore)
+    public static void Show(int finalScore, int distanceMeters, bool insufficientMovement)
     {
         GameObject obj = new GameObject("ExamResultsOverlay");
         // CRÍTICO: DontDestroyOnLoad para que el overlay sobreviva el LoadScene("MainMenu")
@@ -32,6 +36,8 @@ public class ExamResultsScreen : MonoBehaviour
         DontDestroyOnLoad(obj);
         var screen = obj.AddComponent<ExamResultsScreen>();
         screen.score = finalScore;
+        screen.distanceMeters = distanceMeters;
+        screen.insufficientMovement = insufficientMovement;
     }
 
     private float showTime;
@@ -125,10 +131,28 @@ public class ExamResultsScreen : MonoBehaviour
         for (int i = 0; i < faults.Count; i++) totalDeducted += Mathf.Abs(faults[i].points);
 
         bool isPractice = GameManager.Instance != null && GameManager.Instance.IsPracticeMode;
-        Color scoreColor = isPractice ? MenuTheme.TextPrimary : GetScoreColor(score);
-        string scoreLabel = isPractice
-            ? "Modo Práctica\nNo cuenta como examen"
-            : GetScoreLabel(score);
+        Color scoreColor;
+        string scoreLabel;
+        if (insufficientMovement)
+        {
+            // Override de label/color: el examen es inválido por inactividad,
+            // sin importar el score acumulado. Aplica también en modo práctica
+            // para que el alumno entienda por qué la sesión no cuenta.
+            scoreColor = MenuTheme.TextError;
+            scoreLabel = isPractice
+                ? "Práctica inválida\nDistancia recorrida insuficiente"
+                : "NO APTO\nExamen inválido por inactividad";
+        }
+        else if (isPractice)
+        {
+            scoreColor = MenuTheme.TextPrimary;
+            scoreLabel = "Modo Práctica\nNo cuenta como examen";
+        }
+        else
+        {
+            scoreColor = GetScoreColor(score);
+            scoreLabel = GetScoreLabel(score);
+        }
 
         // ── Header: 70-100% del alto de Content ──────────────────────────
         // Título distinto según modo: examen real vs práctica.
@@ -170,7 +194,19 @@ public class ExamResultsScreen : MonoBehaviour
                 : "Detalle de infracciones cometidas durante el examen",
             MenuTheme.CardDescSize, FontStyles.Normal, MenuTheme.TextMuted, TextAlignmentOptions.Left);
         summarySubObj.GetComponent<RectTransform>().Set(
-            new Vector2(0.36f, 0.71f), new Vector2(0.98f, 0.79f), new Vector2(0.5f, 0.5f),
+            new Vector2(0.36f, 0.74f), new Vector2(0.98f, 0.79f), new Vector2(0.5f, 0.5f),
+            Vector2.zero, Vector2.zero);
+
+        // Distancia recorrida — visible siempre. Si fue insuficiente, en rojo.
+        string distanceText = distanceMeters >= 1000
+            ? $"Distancia recorrida: {(distanceMeters / 1000f).ToString("F2", System.Globalization.CultureInfo.InvariantCulture)} km"
+            : $"Distancia recorrida: {distanceMeters} m";
+        Color distanceColor = insufficientMovement ? MenuTheme.TextError : MenuTheme.TextPrimary;
+        FontStyles distanceFs = insufficientMovement ? FontStyles.Bold : FontStyles.Normal;
+        var distanceObj = MenuCardBuilder.CreateText(content, "Distance", distanceText,
+            MenuTheme.CardDescSize, distanceFs, distanceColor, TextAlignmentOptions.Left);
+        distanceObj.GetComponent<RectTransform>().Set(
+            new Vector2(0.36f, 0.71f), new Vector2(0.98f, 0.74f), new Vector2(0.5f, 0.5f),
             Vector2.zero, Vector2.zero);
 
         // ── Tabla: 9-67% del alto de Content ─────────────────────────────
@@ -397,7 +433,10 @@ public class ExamResultsScreen : MonoBehaviour
             // Las pasivas se incluyen aunque tengan points==0 — el alumno
             // sintió el cristal roto/shake/FFB, debe ver la entrada listada
             // para entender que el sistema lo registró pero no lo penalizó.
-            if (e.points < 0 || e.eventType == "COLISION_PASIVA") result.Add(e);
+            // INVALIDO_INACTIVIDAD también con points=0: es la razón principal
+            // del fail, debe verse en la lista de feedback.
+            if (e.points < 0 || e.eventType == "COLISION_PASIVA"
+                || e.eventType == "INVALIDO_INACTIVIDAD") result.Add(e);
         }
         return result;
     }
@@ -407,7 +446,9 @@ public class ExamResultsScreen : MonoBehaviour
     {
         switch (eventType)
         {
-            case "ATROPELLO": return SeverityKind.Critical;
+            case "ATROPELLO":
+            case "INVALIDO_INACTIVIDAD":
+                return SeverityKind.Critical;
             case "COLISION_BICICLETA":
             case "COLISION_VEHICULO":
             case "SEMAFORO_ROJO":

--- a/2026MVP/Assets/Custom/ExamTimer.cs
+++ b/2026MVP/Assets/Custom/ExamTimer.cs
@@ -31,6 +31,23 @@ public class ExamTimer : MonoBehaviour
     private int lastKnownScore = 100;
     private ViolationDetector cachedDetector;
 
+    // ── Tracking de distancia recorrida ─────────────────────────────────
+    // Bug histórico: si el alumno dejaba el coche parado los 3-5 min del examen,
+    // el ViolationDetector no registraba infracciones (todas requieren movimiento)
+    // y EndExam() reportaba passed=true con score=100. Ahora trackeamos distancia
+    // en metros y en EndExam() forzamos passed=false si está bajo el umbral.
+    private Transform playerTransform;
+    private Vector3 lastTrackedPosition;
+    private bool distanceTrackingReady = false;
+    private float distanceMeters = 0f;
+    // Filtra deltas anómalos por respawn (LevantaMoto.cs flips moto, DestrabarAutomovil.cs
+    // teletransporta vehículo atascado tras 5s) o por SpawnLocationManager teleportando
+    // al waypoint Gley inicial. 30 m en un frame implica >1.8 km/s — claramente teleport.
+    private const float MAX_FRAME_DELTA_METERS = 30f;
+    // Defer 1.5 s para que SpawnLocationManager (singleton bootstrap) y PlayerCar.Start()
+    // hayan reposicionado al alumno antes de tomar la posición de referencia.
+    private const float DISTANCE_TRACK_DEFER_SECONDS = 1.5f;
+
     /// <summary>Disparado al final de CreateTimerUI; permite que TopHudRow adopte el container sin race con InitAfterFrame.</summary>
     public System.Action OnContainerReady;
 
@@ -62,6 +79,36 @@ public class ExamTimer : MonoBehaviour
         // Defer 1 frame para que MultiPantallaManager.Start() corra primero y
         // las cámaras tengan ya su targetDisplay reasignado según config.
         StartCoroutine(InitAfterFrame());
+        Invoke(nameof(StartDistanceTracking), DISTANCE_TRACK_DEFER_SECONDS);
+    }
+
+    /// <summary>Distancia acumulada en metros desde que arrancó el tracking.</summary>
+    public int GetDistanceMeters() => Mathf.RoundToInt(distanceMeters);
+
+    void StartDistanceTracking()
+    {
+        playerTransform = FindPlayerTransform();
+        if (playerTransform == null)
+        {
+            // Reintentar 1 vez más por si la escena tardó en cargar al Player.
+            Invoke(nameof(StartDistanceTracking), 0.5f);
+            return;
+        }
+        lastTrackedPosition = playerTransform.position;
+        distanceTrackingReady = true;
+    }
+
+    // Mismo lookup que SpawnLocationManager.cs: PlayerCar de Gley → tag Player → name Player.
+    static Transform FindPlayerTransform()
+    {
+        var pc = Object.FindFirstObjectByType<Gley.UrbanSystem.PlayerCar>();
+        if (pc != null) return pc.transform;
+        GameObject byTag = null;
+        try { byTag = GameObject.FindGameObjectWithTag("Player"); }
+        catch { /* tag no existente: ignorar */ }
+        if (byTag != null) return byTag.transform;
+        var byName = GameObject.Find("Player");
+        return byName != null ? byName.transform : null;
     }
 
     System.Collections.IEnumerator InitAfterFrame()
@@ -210,6 +257,17 @@ public class ExamTimer : MonoBehaviour
     {
         if (examFinished || timerText == null) return;
 
+        // Acumular distancia ANTES del check de timer expirado, para que el
+        // último frame previo a EndExam() también cuente. Si no, podríamos
+        // dejar una sesión válida unos metros bajo el umbral por borde.
+        if (distanceTrackingReady && playerTransform != null)
+        {
+            Vector3 now = playerTransform.position;
+            float delta = Vector3.Distance(now, lastTrackedPosition);
+            if (delta < MAX_FRAME_DELTA_METERS) distanceMeters += delta;
+            lastTrackedPosition = now;
+        }
+
         float remainingTime = examDuration - (Time.time - startTime);
 
         if (remainingTime <= 0f)
@@ -279,6 +337,25 @@ public class ExamTimer : MonoBehaviour
         // Log evento de fin
         TelemetryLogger.Instance?.LogEvent("FIN_EXAMEN", "Tiempo agotado", 0, 0f);
 
+        // Calcular distancia y validar movimiento mínimo ANTES de exportar telemetría
+        // (TelemetryLogger.ExportToJSON lee finalDistanceMeters de ExamTimer.Instance).
+        int distanceInt = GetDistanceMeters();
+        var cfg = ScoringConfig.Instance?.data;
+        int minDistance = cfg?.minValidDistanceMeters ?? 200;
+        int passingScore = cfg?.passingScore ?? 70;
+        bool insufficientMovement = distanceInt < minDistance;
+
+        if (insufficientMovement)
+        {
+            // Mensaje human-friendly: aparece tal cual en el feedback del trámite
+            // (backend construye feedback = faults.map(f => f.description)) y en
+            // ExamResultsScreen para que el examinador entienda por qué reprobó.
+            TelemetryLogger.Instance?.LogEvent(
+                "INVALIDO_INACTIVIDAD",
+                $"Examen inválido: distancia recorrida insuficiente ({distanceInt} m de {minDistance} m requeridos)",
+                0, 0f);
+        }
+
         // Exportar telemetría
         ViolationDetector detector = GetDetector();
         int finalScore = 100;
@@ -288,19 +365,21 @@ public class ExamTimer : MonoBehaviour
             detector.ExportTelemetry();
         }
 
+        bool passed = (finalScore >= passingScore) && !insufficientMovement;
+
         // Disparar evento
         OnExamFinished?.Invoke();
 
         // Enviar resultados al backend (bifurca por modo práctica)
         bool isPractice = GameManager.Instance != null && GameManager.Instance.IsPracticeMode;
-        if (isPractice) SendPracticeResultsToApi(finalScore);
-        else SendResultsToApi(finalScore);
+        if (isPractice) SendPracticeResultsToApi(finalScore, distanceInt);
+        else SendResultsToApi(finalScore, distanceInt, passed);
 
         // Mostrar pantalla de resultados
-        ExamResultsScreen.Show(finalScore);
+        ExamResultsScreen.Show(finalScore, distanceInt, insufficientMovement);
     }
 
-    void SendResultsToApi(int finalScore)
+    void SendResultsToApi(int finalScore, int distanceInt, bool passed)
     {
         string sessionId = GameManager.Instance?.SessionId;
         if (string.IsNullOrEmpty(sessionId))
@@ -309,28 +388,27 @@ public class ExamTimer : MonoBehaviour
             return;
         }
 
-        bool passed = finalScore >= 70;
         var faults = SimulatorApiClient.BuildFaultsFromTelemetry();
 
-        StartCoroutine(SimulatorApiClient.EndSession(sessionId, passed, finalScore, faults, false, (success) =>
+        StartCoroutine(SimulatorApiClient.EndSession(sessionId, passed, finalScore, distanceInt, faults, false, (success) =>
         {
             if (!success)
             {
                 Debug.LogWarning("[ExamTimer] Fallo al enviar resultados — guardando para retry");
-                SimulatorApiClient.SavePendingResult(sessionId, passed, finalScore, faults, false);
+                SimulatorApiClient.SavePendingResult(sessionId, passed, finalScore, distanceInt, faults, false);
             }
         }));
     }
 
-    void SendPracticeResultsToApi(int finalScore)
+    void SendPracticeResultsToApi(int finalScore, int distanceInt)
     {
         var faults = SimulatorApiClient.BuildFaultsFromTelemetry();
-        StartCoroutine(SimulatorApiClient.EndPracticeSession(finalScore, faults, true, (success) =>
+        StartCoroutine(SimulatorApiClient.EndPracticeSession(finalScore, distanceInt, faults, true, (success) =>
         {
             if (!success)
             {
                 Debug.LogWarning("[ExamTimer] Fallo al enviar práctica — guardando para retry");
-                SimulatorApiClient.SavePendingPracticeResult(finalScore, faults, true);
+                SimulatorApiClient.SavePendingPracticeResult(finalScore, distanceInt, faults, true);
             }
         }));
     }
@@ -355,6 +433,7 @@ public class ExamTimer : MonoBehaviour
 
         ViolationDetector det = GetDetector();
         int score = det != null ? det.totalScore : lastKnownScore;
+        int distanceInt = GetDistanceMeters();
         var faults = SimulatorApiClient.BuildFaultsFromTelemetry();
 
         // Modo Práctica: guardar parcial con completed=false (la práctica
@@ -362,8 +441,8 @@ public class ExamTimer : MonoBehaviour
         // no aplica.
         if (GameManager.Instance != null && GameManager.Instance.IsPracticeMode)
         {
-            SimulatorApiClient.SavePendingPracticeResult(score, faults, false);
-            Debug.Log($"[ExamTimer] Práctica interrumpida (score={score}, completed=false)");
+            SimulatorApiClient.SavePendingPracticeResult(score, distanceInt, faults, false);
+            Debug.Log($"[ExamTimer] Práctica interrumpida (score={score}, distance={distanceInt}m, completed=false)");
             return;
         }
 
@@ -371,8 +450,8 @@ public class ExamTimer : MonoBehaviour
         if (string.IsNullOrEmpty(sessionId)) return;
 
         // Examen real interrumpido: passed=false, interrupted=true
-        SimulatorApiClient.SavePendingResult(sessionId, false, score, faults, true);
-        Debug.Log($"[ExamTimer] Examen interrumpido (score={score}, interrupted=true)");
+        SimulatorApiClient.SavePendingResult(sessionId, false, score, distanceInt, faults, true);
+        Debug.Log($"[ExamTimer] Examen interrumpido (score={score}, distance={distanceInt}m, interrupted=true)");
     }
 
     static string FormatTime(float seconds)

--- a/2026MVP/Assets/Custom/ScoringConfig.cs
+++ b/2026MVP/Assets/Custom/ScoringConfig.cs
@@ -49,6 +49,11 @@ public class ScoringConfig : MonoBehaviour
         public int passingScore = 70;
         public GradeThresholds gradeThresholds = new GradeThresholds();
         public int examDurationSeconds = 300;
+        // Distancia mínima (metros) que el alumno debe recorrer durante el examen
+        // para que la sesión sea válida. Si recorre menos, ExamTimer fuerza
+        // passed=false sin importar el score (evita que dejar el coche parado
+        // los 3-5 min sea aprobar con 100). Configurable desde /admin/scoring.
+        public int minValidDistanceMeters = 200;
         public string updatedAt = "";
         public string lastSyncedAt = "";
     }

--- a/2026MVP/Assets/Custom/SimulatorApiClient.cs
+++ b/2026MVP/Assets/Custom/SimulatorApiClient.cs
@@ -48,6 +48,10 @@ public static class SimulatorApiClient
     {
         public bool passed;
         public int score;
+        // Distancia recorrida en metros durante el examen. Backend la usa para
+        // detectar exámenes inválidos por inactividad (alumno dejó el coche
+        // parado y al expirar el timer salía con score 100). 0 si build viejo.
+        public int distanceMeters;
         public SessionFault[] faults;
         public bool interrupted;
     }
@@ -74,6 +78,7 @@ public static class SimulatorApiClient
         public string completedAt;      // ISO 8601 UTC
         public int durationSeconds;
         public int score;
+        public int distanceMeters;
         public SessionFault[] faults;
         public bool completed;
     }
@@ -88,6 +93,7 @@ public static class SimulatorApiClient
         public string kind;
         // Comunes a ambos
         public int score;
+        public int distanceMeters;
         public SessionFault[] faults;
         public string savedAt;
         // Sólo kind=="exam"
@@ -173,7 +179,7 @@ public static class SimulatorApiClient
     /// onComplete recibe true si fue exitoso, false si falló.
     /// </summary>
     public static IEnumerator EndSession(string sessionId, bool passed, int score,
-        SessionFault[] faults, bool interrupted, System.Action<bool> onComplete)
+        int distanceMeters, SessionFault[] faults, bool interrupted, System.Action<bool> onComplete)
     {
         string url = $"{BaseUrl}/simulator/sessions/{sessionId}/results";
 
@@ -181,12 +187,13 @@ public static class SimulatorApiClient
         {
             passed = passed,
             score = score,
+            distanceMeters = distanceMeters,
             faults = faults,
             interrupted = interrupted
         };
 
         string json = JsonUtility.ToJson(requestBody);
-        Debug.Log($"[SimulatorAPI] POST {url} score={score} passed={passed} faults={faults?.Length ?? 0}");
+        Debug.Log($"[SimulatorAPI] POST {url} score={score} passed={passed} distance={distanceMeters}m faults={faults?.Length ?? 0}");
 
         using (var request = new UnityWebRequest(url, "POST"))
         {
@@ -219,8 +226,8 @@ public static class SimulatorApiClient
     /// completed=true cuando los 3 min terminaron normales; false si interrumpido.
     /// onComplete recibe true si fue exitoso, false si falló.
     /// </summary>
-    public static IEnumerator EndPracticeSession(int finalScore, SessionFault[] faults,
-        bool completed, System.Action<bool> onComplete)
+    public static IEnumerator EndPracticeSession(int finalScore, int distanceMeters,
+        SessionFault[] faults, bool completed, System.Action<bool> onComplete)
     {
         string url = $"{BaseUrl}/simulator/practice-results";
         var gm = GameManager.Instance;
@@ -245,12 +252,13 @@ public static class SimulatorApiClient
             completedAt = System.DateTime.UtcNow.ToString("o"),
             durationSeconds = completed ? 180 : duration,
             score = finalScore,
+            distanceMeters = distanceMeters,
             faults = faults,
             completed = completed,
         };
 
         string json = JsonUtility.ToJson(requestBody);
-        Debug.Log($"[SimulatorAPI] POST {url} score={finalScore} vehicle={requestBody.vehicleType} completed={completed}");
+        Debug.Log($"[SimulatorAPI] POST {url} score={finalScore} distance={distanceMeters}m vehicle={requestBody.vehicleType} completed={completed}");
 
         using (var request = new UnityWebRequest(url, "POST"))
         {
@@ -322,6 +330,9 @@ public static class SimulatorApiClient
             case "CAMBIO_PELIGROSO": return "dangerous-gear-change";
             case "CAMBIO_SIN_CLUTCH": return "gear-change-without-clutch";
             case "FIN_EXAMEN": return "exam-end";
+            // Razón principal del fail cuando el alumno se queda parado:
+            // aparece en el feedback del trámite y en la pantalla de resultados.
+            case "INVALIDO_INACTIVIDAD": return "inactivity-invalid";
             default: return eventType.ToLower();
         }
     }
@@ -330,7 +341,10 @@ public static class SimulatorApiClient
     {
         switch (eventType)
         {
-            case "ATROPELLO": return "critical";
+            case "ATROPELLO":
+            // Inactividad reprueba directo aunque no descuente puntos —
+            // tratamos como crítica para que destaque arriba del feedback.
+            case "INVALIDO_INACTIVIDAD": return "critical";
             case "COLISION_BICICLETA":
             case "COLISION_VEHICULO":
             case "COLISION":
@@ -366,7 +380,7 @@ public static class SimulatorApiClient
 
     /// <summary>Guarda un resultado fallido para retry posterior.</summary>
     public static void SavePendingResult(string sessionId, bool passed, int score,
-        SessionFault[] faults, bool interrupted = false)
+        int distanceMeters, SessionFault[] faults, bool interrupted = false)
     {
         var list = LoadPendingResults();
         list.results.Add(new PendingResult
@@ -375,6 +389,7 @@ public static class SimulatorApiClient
             sessionId = sessionId,
             passed = passed,
             score = score,
+            distanceMeters = distanceMeters,
             faults = faults,
             savedAt = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
             interrupted = interrupted
@@ -387,7 +402,8 @@ public static class SimulatorApiClient
     }
 
     /// <summary>Guarda una práctica fallida para retry posterior.</summary>
-    public static void SavePendingPracticeResult(int score, SessionFault[] faults, bool completed)
+    public static void SavePendingPracticeResult(int score, int distanceMeters,
+        SessionFault[] faults, bool completed)
     {
         var gm = GameManager.Instance;
         var config = SimulatorConfig.Instance?.data;
@@ -403,6 +419,7 @@ public static class SimulatorApiClient
         {
             kind = "practice",
             score = score,
+            distanceMeters = distanceMeters,
             faults = faults,
             savedAt = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
             practiceId = gm?.PracticeId ?? System.Guid.NewGuid().ToString(),
@@ -468,7 +485,7 @@ public static class SimulatorApiClient
             else
             {
                 yield return EndSession(pending.sessionId, pending.passed, pending.score,
-                    pending.faults, pending.interrupted, (ok) => success = ok);
+                    pending.distanceMeters, pending.faults, pending.interrupted, (ok) => success = ok);
                 if (success) Debug.Log($"[SimulatorAPI] Resultado pendiente {pending.sessionId} enviado");
             }
 
@@ -508,6 +525,7 @@ public static class SimulatorApiClient
             completedAt = p.completedAt,
             durationSeconds = p.durationSeconds,
             score = p.score,
+            distanceMeters = p.distanceMeters,
             faults = p.faults,
             completed = p.completed,
         };

--- a/2026MVP/Assets/Custom/TelemetryLogger.cs
+++ b/2026MVP/Assets/Custom/TelemetryLogger.cs
@@ -17,7 +17,7 @@ public class TelemetryLogger : MonoBehaviour
         public float speed;                                                                                                                                                
     }                                                                                                                                                                      
                                                                                                                                                                             
-    [System.Serializable]                                                                                                                                                  
+    [System.Serializable]
     public class TelemetryData
     {
         public string sessionId;
@@ -26,8 +26,9 @@ public class TelemetryLogger : MonoBehaviour
         public string tramiteId;
         public float examDurationSeconds;
         public int finalScore;
+        public int finalDistanceMeters;
         public List<TelemetryEvent> events = new List<TelemetryEvent>();
-    }                                                                                                                                                                      
+    }                                                                                                                                                                  
                                                                                                                                                                             
     public TelemetryData data = new TelemetryData();                                                                                                                       
     private float sessionStartTime;                                                                                                                                        
@@ -61,7 +62,8 @@ public class TelemetryLogger : MonoBehaviour
         data.sessionId = GameManager.Instance?.SessionId ?? "";
         data.tramiteId = GameManager.Instance?.Expediente ?? "";
         data.examDurationSeconds = ExamTimer.Instance?.examDuration ?? 300f;
-        data.finalScore = finalScore;                                                 
+        data.finalScore = finalScore;
+        data.finalDistanceMeters = ExamTimer.Instance?.GetDistanceMeters() ?? 0;                                            
                                                                                         
         string json = JsonUtility.ToJson(data, true);                                 
         string filename = $"telemetry_{DateTime.Now:yyyyMMdd_HHmmss}.json";           

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.3.7
+  bundleVersion: 1.3.8
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
## Resumen

- **Bug**: dejar el coche parado los 3 min de práctica reportaba `passed=true, score=100`. `ViolationDetector.totalScore` arranca en 100 y solo decrementa por infracciones que requieren movimiento (colisión >3 km/h, exceso de velocidad, etc.). Sin movimiento = sin faltas = aprobado con 100.
- **Fix**: `ExamTimer` trackea distancia recorrida (`Vector3.Distance` por frame, filtra deltas >30m anti-teleport). `EndExam` aplica `passed = (score>=passingScore) && (distance>=minValidDistanceMeters)` (default 200m, configurable desde `/admin/scoring`). Si la distancia es insuficiente, `passed=false` con falta crítica `INVALIDO_INACTIVIDAD` que aparece en el feedback del trámite y en la pantalla de resultados.

Bump `bundleVersion` `1.3.7` → `1.3.8`.

## Contratos coordinados

Este PR depende de los siguientes commits ya en `dev` de los otros repos:
- portal-backend `feat(scoring): minValidDistanceMeters + distanceMeters en results` (commit `4609eb1`)
- portal `feat(admin): distancia recorrida + umbral mínimo válido del examen` (commit `852224e`)

Builds Unity <1.3.8 siguen funcionando — el backend persiste `distanceMeters` solo si vino en el body, y la UI lo muestra como "—" sin marcar inválido.

## Archivos clave

- `Assets/Custom/ExamTimer.cs` — tracking + lógica `passed` + log `INVALIDO_INACTIVIDAD`
- `Assets/Custom/SimulatorApiClient.cs` — `distanceMeters` en `EndSession*`/`SavePending*`/retry; mapeo `inactivity-invalid` con severity `critical`
- `Assets/Custom/ScoringConfig.cs` — `minValidDistanceMeters` (default 200)
- `Assets/Custom/ExamResultsScreen.cs` — label "NO APTO\nExamen inválido por inactividad" + línea de distancia + entrada en tabla de faltas
- `Assets/Custom/TelemetryLogger.cs` — `finalDistanceMeters` en JSON local

## Test plan

- [ ] Smoke: iniciar modo práctica, dejar coche parado 3 min → "NO APTO — Práctica inválida — Distancia recorrida insuficiente"
- [ ] Smoke: arrancar y avanzar ~50 m, parar → invalidado por inactividad (50 < 200)
- [ ] Smoke: conducir normal, recorrer ≥200 m → resultado normal según score
- [ ] Verificar en `/admin/simuladores/practicas` que la columna "Distancia" se muestra y la bandera roja aparece para sesiones inválidas
- [ ] Verificar que builds <1.3.8 ya en kioskos (Aramis, etc.) siguen reportando práctica sin que aparezca como inválida

## Review previo

Revisado por Codex (gpt-5.2-codex) — encontró 1 bug + 1 riesgo, ambos arreglados antes de este push:
1. Backend persistía `distanceMeters: 0` para builds viejos → fix: persistir solo si vino en body
2. Último frame antes de `EndExam()` no acumulaba distancia → fix: mover acumulación al inicio de `Update()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)