### PR TITLE
fix(autoupdater): force-kill Unity tras 10s, evita ciclo INSTALLING infinito

### DIFF
--- a/2026MVP/Assets/Custom/AutoUpdater.cs
+++ b/2026MVP/Assets/Custom/AutoUpdater.cs
@@ -418,16 +418,18 @@ set WAIT=0
 :waitloop
 tasklist /FI ""IMAGENAME eq {exeName}"" 2>NUL | find /I ""{exeName}"" >NUL
 if errorlevel 1 goto continue_install
-if %WAIT% GEQ 30 (
-    echo WARN: Unity no cerro tras 30s, continuando...
-    echo %DATE% %TIME% WARN: Unity did not exit after 30s >> ""{batInstallLog}""
+if %WAIT% GEQ 10 (
+    echo WARN: Unity no cerro tras 10s, forzando taskkill...
+    echo %DATE% %TIME% WARN: Unity did not exit after 10s, forcing taskkill /F >> ""{batInstallLog}""
+    taskkill /F /IM ""{exeName}"" >NUL 2>&1
+    timeout /t 3 /nobreak >nul
     goto continue_install
 )
 timeout /t 2 /nobreak >nul
 set /a WAIT+=2
 goto waitloop
 :continue_install
-echo %DATE% %TIME% Unity closed, proceeding >> ""{batInstallLog}""
+echo %DATE% %TIME% Unity closed (or force-killed), proceeding >> ""{batInstallLog}""
 
 echo Extrayendo archivos y limpiando Mark-of-the-Web...
 powershell {psFlags} ""Expand-Archive -Path '{psZipPath}' -DestinationPath '{psStagingDir}' -Force; Get-ChildItem -Path '{psStagingDir}' -Recurse -File | Unblock-File""


### PR DESCRIPTION
## Resumen

El bat de update esperaba hasta 30s a que Unity cerrara y, si no cerraba,
**procedía con xcopy de todos modos** — pero como `UnityPlayer.dll` y otros
archivos quedan locked por el proceso vivo, xcopy fallaba con `errorlevel 1`
y el bat caía en `:fail`, relanzando el `.exe` original. El AutoUpdater fresh
re-detectaba el `pendingUpdate` y arrancaba el ciclo de nuevo (DOWNLOADING
→ INSTALLING → bat fail → relaunch → DOWNLOADING → ...) infinito.

## Síntoma observado (2026-05-03)

5 kioskos productivos atascados cycling cada ~30-60s sin progresar a
INSTALLED:
- SIM-003 Sedan 1
- SIM-004 Sedan 2
- SIM-005 Pasajeros 1
- SIM-007 Motocicleta
- Emergencia

Aramis (SIM-008) y BUS (SIM-006) instalaron OK porque su Unity sí cerró
dentro de los 30s. La diferencia parece ser drivers HID (G923, HORI Truck)
que retrasan `OnApplicationQuit()` impredeciblemente en los kioskos
productivos.

## Fix

A los 10s de espera (en vez de 30s), `taskkill /F /IM <exe>`, sleep 3s, y
luego proceder con xcopy. Garantiza que xcopy actúa sobre filesystem libre
y completa OK.

## Test plan

- [ ] **Próximo OTA después de mergear**: build 1.3.10 → el bat generado
  por la nueva Unity debe incluir `taskkill /F` y completar el install
  aunque Unity tarde en quit.
- [ ] **Regresión Aramis (sin HID conflict)**: instalar 1.3.10 y verificar
  que sigue funcionando como antes (no debería notar diferencia, taskkill
  solo activa si Unity no cerró en 10s).
- [ ] **Bootstrap manual de los 5 stuck**: usar `install-1.3.10-manual.ps1`
  para llevarlos de 1.3.5/1.3.6 → 1.3.10 una vez. De ahí en adelante OTAs
  limpios.

## Causa raíz

Aplicaciones con drivers HID o subsistemas de audio retrasan
`OnApplicationQuit()` impredeciblemente. La estrategia "esperar y rezar"
no es robusta; force-kill es la única garantía.