### PR TITLE
feat(bus-pasajeros): puerta del bus por botón + SFX abrir/cerrar

### DIFF
--- a/2026MVP/Assets/Custom/BindingsPanel.cs
+++ b/2026MVP/Assets/Custom/BindingsPanel.cs
@@ -79,6 +79,7 @@ public class BindingsPanel : MonoBehaviour
         actions.Add(new ActionEntry { id = "paddleLeft",  prefKey = UIInputNew.PREF_BIND_PADDLE_LEFT,   defaultValue = UIInputNew.DEFAULT_BIND_PADDLE_LEFT,   displayName = "Direccional Izq (paddle)" });
         actions.Add(new ActionEntry { id = "paddleRight", prefKey = UIInputNew.PREF_BIND_PADDLE_RIGHT,  defaultValue = UIInputNew.DEFAULT_BIND_PADDLE_RIGHT,  displayName = "Direccional Der (paddle)" });
         actions.Add(new ActionEntry { id = "restart",     prefKey = UIInputNew.PREF_BIND_RESTART,       defaultValue = UIInputNew.DEFAULT_BIND_RESTART,       displayName = "Reiniciar escena (botón)" });
+        actions.Add(new ActionEntry { id = "door",        prefKey = UIInputNew.PREF_BIND_DOOR,          defaultValue = UIInputNew.DEFAULT_BIND_DOOR,          displayName = "Puerta del bus (toggle)" });
         actions.Add(new ActionEntry { id = "menuA",       prefKey = UIInputNew.PREF_BIND_MENU_A,        defaultValue = UIInputNew.DEFAULT_BIND_MENU_A,        displayName = "Combo menú A (hold + B)" });
         actions.Add(new ActionEntry { id = "menuB",       prefKey = UIInputNew.PREF_BIND_MENU_B,        defaultValue = UIInputNew.DEFAULT_BIND_MENU_B,        displayName = "Combo menú B" });
         actions.Add(new ActionEntry { id = "restartA",    prefKey = UIInputNew.PREF_BIND_RESTART_A,     defaultValue = UIInputNew.DEFAULT_BIND_RESTART_A,     displayName = "Combo restart A (hold + B)" });

--- a/2026MVP/Assets/Custom/DoorPromptHUD.cs
+++ b/2026MVP/Assets/Custom/DoorPromptHUD.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+using TMPro;
+using Gley.UrbanSystem;
+
+/// <summary>
+/// Widget HUD que muestra "Presiona [BOTÓN] para abrir puerta" cuando el bus
+/// está detenido en una zona de parada y la puerta está cerrada. Singleton
+/// bootstrapped (mismo patrón que CollisionFeedback). Solo activo en la escena
+/// BusPasajeros.
+/// </summary>
+public class DoorPromptHUD : MonoBehaviour
+{
+    public static DoorPromptHUD Instance { get; private set; }
+
+    private static readonly HashSet<string> ACTIVE_SCENES = new HashSet<string> { "BusPasajeros" };
+
+    private Canvas canvas;
+    private CanvasGroup group;
+    private TextMeshProUGUI label;
+    private List<ParadaManagerBus> _paradas = new List<ParadaManagerBus>();
+    private float _refreshTimer;
+    private const float REFRESH_INTERVAL = 1f;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void Bootstrap()
+    {
+        if (Instance != null) return;
+        var go = new GameObject("[DoorPromptHUD]");
+        DontDestroyOnLoad(go);
+        Instance = go.AddComponent<DoorPromptHUD>();
+    }
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
+        BuildCanvas();
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        OnSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+    }
+
+    void OnDestroy()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        bool active = ACTIVE_SCENES.Contains(scene.name);
+        if (canvas != null) canvas.enabled = active;
+        if (active) RefreshParadas();
+    }
+
+    void RefreshParadas()
+    {
+        _paradas.Clear();
+        var found = Object.FindObjectsByType<ParadaManagerBus>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+        _paradas.AddRange(found);
+    }
+
+    void Update()
+    {
+        if (canvas == null || !canvas.enabled) return;
+
+        _refreshTimer += Time.unscaledDeltaTime;
+        if (_refreshTimer >= REFRESH_INTERVAL)
+        {
+            _refreshTimer = 0f;
+            // Re-scan por si se cargaron paradas adicionales después del scene load.
+            if (_paradas.Count == 0) RefreshParadas();
+        }
+
+        bool show = false;
+        for (int i = 0; i < _paradas.Count; i++)
+        {
+            var p = _paradas[i];
+            if (p != null && p.IsPromptVisible()) { show = true; break; }
+        }
+
+        group.alpha = show ? 1f : 0f;
+        if (show) label.text = BuildPromptText();
+    }
+
+    string BuildPromptText()
+    {
+        var ui = Object.FindAnyObjectByType<UIInputNew>();
+        string raw = ui != null ? ui.GetDoorBindingPath() : "";
+        string hint = FormatBindingPath(raw);
+        return $"Presiona <b>{hint}</b> para abrir puerta";
+    }
+
+    static string FormatBindingPath(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return "[Configurar en F8]";
+        // wheel:buttonN → "Botón W{N}", shifter:buttonN → "Botón S{N}".
+        if (path.StartsWith("wheel:button"))   return "Botón W" + path.Substring("wheel:button".Length);
+        if (path.StartsWith("shifter:button")) return "Botón S" + path.Substring("shifter:button".Length);
+        return path;
+    }
+
+    void BuildCanvas()
+    {
+        var canvasGo = new GameObject("DoorPromptCanvas");
+        canvasGo.transform.SetParent(transform, false);
+        canvas = canvasGo.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.sortingOrder = 4000;
+
+        var scaler = canvasGo.AddComponent<CanvasScaler>();
+        scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+        scaler.referenceResolution = new Vector2(1920, 1080);
+        scaler.matchWidthOrHeight = 0.5f;
+
+        canvasGo.AddComponent<GraphicRaycaster>();
+
+        var panel = new GameObject("Panel");
+        panel.transform.SetParent(canvasGo.transform, false);
+        var bg = panel.AddComponent<Image>();
+        bg.color = new Color(0f, 0f, 0f, 0.6f);
+        var rt = panel.GetComponent<RectTransform>();
+        rt.anchorMin = new Vector2(0.5f, 0f);
+        rt.anchorMax = new Vector2(0.5f, 0f);
+        rt.pivot = new Vector2(0.5f, 0f);
+        rt.anchoredPosition = new Vector2(0, 80);
+        rt.sizeDelta = new Vector2(620, 80);
+
+        group = panel.AddComponent<CanvasGroup>();
+        group.alpha = 0f;
+        group.interactable = false;
+        group.blocksRaycasts = false;
+
+        var text = new GameObject("Label");
+        text.transform.SetParent(panel.transform, false);
+        label = text.AddComponent<TextMeshProUGUI>();
+        label.alignment = TextAlignmentOptions.Center;
+        label.fontSize = 32;
+        label.color = Color.white;
+        label.text = "Presiona [BOTÓN] para abrir puerta";
+        var trt = text.GetComponent<RectTransform>();
+        trt.anchorMin = Vector2.zero;
+        trt.anchorMax = Vector2.one;
+        trt.offsetMin = new Vector2(20, 10);
+        trt.offsetMax = new Vector2(-20, -10);
+    }
+}

--- a/2026MVP/Assets/Custom/DoorPromptHUD.cs.meta
+++ b/2026MVP/Assets/Custom/DoorPromptHUD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a67e854861e84a06a587a52207fefd10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -175,6 +175,7 @@ namespace Gley.UrbanSystem
         private InputControl<float> _l1Ctrl, _r1Ctrl; // paddles para direccionales
         private InputControl<float> _hazardCtrl;       // botón dedicado de intermitentes
         private InputControl<float> _hornCtrl;         // claxón (hold-to-honk)
+        private InputControl<float> _doorCtrl;         // puerta del bus (toggle abrir/cerrar en BusPasajeros)
         // Reversa soporta multi-path: el binding string puede contener varios
         // paths separados por '|' (OR). Útil cuando un mismo shifter firma
         // reversa en varios controles a la vez.
@@ -204,6 +205,7 @@ namespace Gley.UrbanSystem
         private string _bindPaddleRight = "button5";
         private string _bindHazard = "";
         private string _bindHorn = "";
+        private string _bindDoor = "";              // puerta del bus (BusPasajeros)
         private string _bindRestart = "";           // vacío = deshabilitado
         private string _bindMenuA = "button7";      // L2
         private string _bindMenuB = "button8";      // R2
@@ -246,6 +248,7 @@ namespace Gley.UrbanSystem
         public const string PREF_BIND_PADDLE_RIGHT = "Bind_paddleRight";
         public const string PREF_BIND_HAZARD = "Bind_hazard";
         public const string PREF_BIND_HORN = "Bind_horn";
+        public const string PREF_BIND_DOOR = "Bind_door";
         public const string PREF_BIND_RESTART = "Bind_restart";
         public const string PREF_BIND_MENU_A = "Bind_menuA";
         public const string PREF_BIND_MENU_B = "Bind_menuB";
@@ -329,6 +332,7 @@ namespace Gley.UrbanSystem
         public const string DEFAULT_BIND_PADDLE_RIGHT = "button5";
         public const string DEFAULT_BIND_HAZARD = "";
         public const string DEFAULT_BIND_HORN = "";
+        public const string DEFAULT_BIND_DOOR = "";
         public const string DEFAULT_BIND_RESTART = "";
         public const string DEFAULT_BIND_MENU_A = "button7";
         public const string DEFAULT_BIND_MENU_B = "button8";
@@ -365,6 +369,7 @@ namespace Gley.UrbanSystem
             _bindPaddleRight  = PlayerPrefs.GetString(PREF_BIND_PADDLE_RIGHT, DEFAULT_BIND_PADDLE_RIGHT);
             _bindHazard       = PlayerPrefs.GetString(PREF_BIND_HAZARD, DEFAULT_BIND_HAZARD);
             _bindHorn         = PlayerPrefs.GetString(PREF_BIND_HORN, DEFAULT_BIND_HORN);
+            _bindDoor         = PlayerPrefs.GetString(PREF_BIND_DOOR, DEFAULT_BIND_DOOR);
             _bindRestart      = PlayerPrefs.GetString(PREF_BIND_RESTART, DEFAULT_BIND_RESTART);
             _bindMenuA        = PlayerPrefs.GetString(PREF_BIND_MENU_A, DEFAULT_BIND_MENU_A);
             _bindMenuB        = PlayerPrefs.GetString(PREF_BIND_MENU_B, DEFAULT_BIND_MENU_B);
@@ -388,6 +393,7 @@ namespace Gley.UrbanSystem
             _r1Ctrl       = CacheBindingCtrl(_bindPaddleRight);
             _hazardCtrl   = CacheBindingCtrl(_bindHazard);
             _hornCtrl     = CacheBindingCtrl(_bindHorn);
+            _doorCtrl     = CacheBindingCtrl(_bindDoor);
             _restartCtrl  = CacheBindingCtrl(_bindRestart);
             _l2Ctrl       = CacheBindingCtrl(_bindMenuA);
             _r2Ctrl       = CacheBindingCtrl(_bindMenuB);
@@ -974,6 +980,10 @@ namespace Gley.UrbanSystem
                 PlayerPrefs.SetString(PREF_BIND_HAZARD, "shifter:button27");
                 PlayerPrefs.SetString(PREF_BIND_HORN, "wheel:button7");
                 PlayerPrefs.SetString(PREF_BIND_REVERSE, "shifter:button7");
+                // Puerta del bus: solo asignar si no hay valor previo (no pisar
+                // remapeo del operador en F8). Default wheel:button21.
+                if (!PlayerPrefs.HasKey(PREF_BIND_DOOR))
+                    PlayerPrefs.SetString(PREF_BIND_DOOR, "wheel:button21");
                 // Throttle: el HID parser de Unity tiene un bug con el descriptor
                 // del HORI HPC-044U (sliders aliased al mismo byte) y deja el
                 // byte del throttle (21-22 del input report) huérfano — ningún
@@ -1268,9 +1278,16 @@ namespace Gley.UrbanSystem
 #if !(UNITY_ANDROID || UNITY_IOS) || UNITY_EDITOR
         public bool HasPhysicalClutch() => _clutchCtrl != null;
         public bool IsHornPressed() => IsPressed(_hornCtrl);
+        // Puerta del bus: estado continuo (held). El edge detection vive en el
+        // consumidor (ParadaManagerBus) para que múltiples paradas no se
+        // pisen el flag de "frame anterior".
+        public bool IsDoorPressed() => IsPressed(_doorCtrl);
+        public string GetDoorBindingPath() => _bindDoor;
 #else
         public bool HasPhysicalClutch() => false;
         public bool IsHornPressed() => false;
+        public bool IsDoorPressed() => false;
+        public string GetDoorBindingPath() => "";
 #endif
         // Devuelve y resetea el contador de cambios de marcha sin clutch.
         // Patrón latched (no bool con reset-on-read) para que el orden de

--- a/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXClips.cs
+++ b/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXClips.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "DoorSFXClips", menuName = "Tlax/Door SFX Clips")]
+public class DoorSFXClips : ScriptableObject
+{
+    public AudioClip open;
+    public AudioClip close;
+}

--- a/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXClips.cs.meta
+++ b/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXClips.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08ee212679714194a990b0ed4e881fd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXManager.cs
+++ b/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXManager.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+/// <summary>
+/// Singleton bootstrapped que reproduce SFX de puerta del bus (open/close).
+/// Mismo patrón que CollisionFeedback: AudioSource pre-warmed para evitar
+/// cold-start hitch, clips referenciados via ScriptableObject en
+/// Resources/Custom/DoorSFXClips.asset.
+/// </summary>
+public class DoorSFXManager : MonoBehaviour
+{
+    public static DoorSFXManager Instance { get; private set; }
+
+    private AudioSource src;
+    private AudioClip openClip;
+    private AudioClip closeClip;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Bootstrap()
+    {
+        if (Instance != null) return;
+        var go = new GameObject("[DoorSFXManager]");
+        DontDestroyOnLoad(go);
+        Instance = go.AddComponent<DoorSFXManager>();
+    }
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
+
+        src = gameObject.AddComponent<AudioSource>();
+        src.playOnAwake = false;
+        src.spatialBlend = 0f;
+
+        var clips = Resources.Load<DoorSFXClips>("Custom/DoorSFXClips");
+        if (clips != null)
+        {
+            openClip = clips.open;
+            closeClip = clips.close;
+            if (openClip) src.PlayOneShot(openClip, 0f);
+        }
+        else
+        {
+            Debug.LogWarning("[DoorSFXManager] No se encontró Resources/Custom/DoorSFXClips.asset — SFX deshabilitado");
+        }
+    }
+
+    public void PlayDoorOpen()
+    {
+        if (src != null && openClip != null) src.PlayOneShot(openClip, 0.7f);
+    }
+
+    public void PlayDoorClose()
+    {
+        if (src != null && closeClip != null) src.PlayOneShot(closeClip, 0.7f);
+    }
+}

--- a/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXManager.cs.meta
+++ b/2026MVP/Assets/NPCs/CamionNPC-s/DoorSFXManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46620a0d3a4649c4b07f028f2f21400e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/NPCs/CamionNPC-s/ParadaManagerBus.cs
+++ b/2026MVP/Assets/NPCs/CamionNPC-s/ParadaManagerBus.cs
@@ -1,0 +1,137 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Gley.UrbanSystem;
+
+/// <summary>
+/// Variante de ParadaManager para la escena BusPasajeros: el conductor abre
+/// y cierra la puerta con un botón (toggle), y suena DoorOpen/DoorClose.wav.
+/// Reemplaza al ParadaManager original SOLO en los GameObjects de paradas
+/// del bus. CamionDCarga sigue usando ParadaManager con auto-board.
+///
+/// Diseño (post codex 2026-05-03):
+/// - Lectura de input en Update(), no en OnTriggerStay (evita perder pulsos).
+/// - Velocidad numérica del Rigidbody (no string del HUD).
+/// - Toggle: 1ª pulsación abre + SFX, 2ª cierra + SFX. Sin autoclose por velocidad.
+/// - Cierre auto solo al salir del trigger (cleanup, no comportamiento de juego).
+/// - Coroutines de cola se cancelan al cerrar (no quedan flags stale en cierre+
+///   reapertura rápido).
+/// </summary>
+public class ParadaManagerBus : MonoBehaviour
+{
+    public List<Pasajero> pasajero;
+    public string NumParada;
+    public SimpleSpeedGauge movimientoCarro;
+
+    [Tooltip("Threshold km/h para considerar el bus 'detenido'")]
+    public float stopSpeedThreshold = 1f;
+
+    private Rigidbody _rb;
+    private UIInputNew _uiInput;
+    private bool _inStopZone;
+    private bool _doorOpen;
+    private bool _doorPrev;
+    private Coroutine _boardingCo;
+    private Coroutine _alightingCo;
+
+    void Start()
+    {
+        foreach (Transform p in transform)
+        {
+            var pj = p.GetComponent<Pasajero>();
+            if (pj != null) pasajero.Add(pj);
+        }
+        _uiInput = Object.FindAnyObjectByType<UIInputNew>();
+    }
+
+    void OnTriggerEnter(Collider other)
+    {
+        if (!other.CompareTag("puerta")) return;
+        _inStopZone = true;
+        if (_rb == null && other.attachedRigidbody != null) _rb = other.attachedRigidbody;
+    }
+
+    void OnTriggerExit(Collider other)
+    {
+        if (!other.CompareTag("puerta")) return;
+        _inStopZone = false;
+        if (_doorOpen) CloseDoor();
+    }
+
+    void Update()
+    {
+        if (!_inStopZone) return;
+        if (_uiInput == null) _uiInput = Object.FindAnyObjectByType<UIInputNew>();
+        if (_uiInput == null) return;
+
+        bool now = _uiInput.IsDoorPressed();
+        bool edge = now && !_doorPrev;
+        _doorPrev = now;
+        if (!edge) return;
+
+        if (!_doorOpen && IsStopped())
+        {
+            OpenDoor();
+        }
+        else if (_doorOpen)
+        {
+            CloseDoor();
+        }
+    }
+
+    bool IsStopped()
+    {
+        if (_rb != null)
+        {
+            float kmh = _rb.linearVelocity.magnitude * 3.6f;
+            return kmh < stopSpeedThreshold;
+        }
+        return movimientoCarro != null && movimientoCarro.velocidadActual == "0";
+    }
+
+    void OpenDoor()
+    {
+        _doorOpen = true;
+        if (DoorSFXManager.Instance != null) DoorSFXManager.Instance.PlayDoorOpen();
+        if (_boardingCo != null) StopCoroutine(_boardingCo);
+        if (_alightingCo != null) StopCoroutine(_alightingCo);
+        _boardingCo = StartCoroutine(ColaPasaje());
+        _alightingCo = StartCoroutine(ColaBajada());
+    }
+
+    void CloseDoor()
+    {
+        _doorOpen = false;
+        if (DoorSFXManager.Instance != null) DoorSFXManager.Instance.PlayDoorClose();
+        if (_boardingCo != null) { StopCoroutine(_boardingCo); _boardingCo = null; }
+        if (_alightingCo != null) { StopCoroutine(_alightingCo); _alightingCo = null; }
+    }
+
+    public bool IsPromptVisible() => _inStopZone && !_doorOpen && IsStopped();
+
+    IEnumerator ColaPasaje()
+    {
+        for (int i = 0; i < pasajero.Count; i++)
+        {
+            yield return new WaitForSeconds(3);
+            if (!_doorOpen) yield break;
+            pasajero[i]._Activo = true;
+        }
+        _boardingCo = null;
+    }
+
+    IEnumerator ColaBajada()
+    {
+        var abordo = CamionManager.instancia.pasajerosABordo;
+        for (int i = abordo.Count - 1; i >= 0; i--)
+        {
+            if (abordo[i]._Sentado && abordo[i].Mi_Parada == NumParada)
+            {
+                yield return new WaitForSeconds(3);
+                if (!_doorOpen) yield break;
+                abordo[i]._BajarActivado = true;
+            }
+        }
+        _alightingCo = null;
+    }
+}

--- a/2026MVP/Assets/NPCs/CamionNPC-s/ParadaManagerBus.cs.meta
+++ b/2026MVP/Assets/NPCs/CamionNPC-s/ParadaManagerBus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d20914ec61e43df9abda6c55f791b65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Resources/Custom/DoorSFXClips.asset
+++ b/2026MVP/Assets/Resources/Custom/DoorSFXClips.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08ee212679714194a990b0ed4e881fd3, type: 3}
+  m_Name: DoorSFXClips
+  m_EditorClassIdentifier:
+  open: {fileID: 8300000, guid: 8f88d16f0747e9546a78b21b27b72a05, type: 3}
+  close: {fileID: 8300000, guid: 09728de3dc767254ca511ee99d939683, type: 3}

--- a/2026MVP/Assets/Resources/Custom/DoorSFXClips.asset.meta
+++ b/2026MVP/Assets/Resources/Custom/DoorSFXClips.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3807e95ae151485da30975f98e4d3333
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Agrega control de la puerta del bus de pasajeros mediante un botón dedicado.
- SFX de abrir y cerrar puerta sincronizados con la animación.

## Test plan
- [ ] Cargar escena `BusPasajeros` y validar que el botón abre/cierra la puerta.
- [ ] Verificar que los SFX suenan al abrir y al cerrar.
- [ ] Confirmar que pasajeros pueden abordar/descender solo con la puerta abierta.