### PR TITLE
feat(wipers): auto-on por clima + HORI 42/43 + sacar tecla E (1.3.12)

### DIFF
--- a/2026MVP/Assets/Custom/WiperAutoController.cs
+++ b/2026MVP/Assets/Custom/WiperAutoController.cs
@@ -1,0 +1,160 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+using UnityEngine.SceneManagement;
+using ShadedTechnology.WindshieldRainAsset.Demo;
+
+/// <summary>
+/// Maneja los wipers en escenas de manejo (Sedan, Camioneta, Ambulancia,
+/// CamionDCarga). Tres responsabilidades:
+///
+/// 1) Auto-on cuando hay precipitación: al cargar escena, lee
+///    <c>PlayerPrefs.GetInt("Clima")</c> (0=Sol, 1=Lluvia, 2=Granizo) y llama
+///    <see cref="ControllWipers.SetMode"/> con modo 2 (latcheado medio) o 0.
+///
+/// 2) Anula el binding <c>&lt;Keyboard&gt;/e</c> heredado del demo del asset
+///    WindshieldRainAsset (commit 486906e4 cabló un PlayerInput hacia el
+///    inputactions del demo). Sin esto, pulsar E activa wiper Y direccional
+///    derecha (PlayerCar.cs:286 lee eKey directo del Keyboard.current).
+///
+/// 3) Polling de HORI HPC-044U: button42 → wipers OFF, button43 → ON latcheado.
+///    Acceso directo al device (no path strings) porque el HORI puede
+///    registrarse como Joystick en vez de HID y un binding genérico fallaría.
+///
+/// Bootstrap singleton (AfterSceneLoad) — no requiere setup en escena.
+/// Excluye MainMenu y Motocicleta.
+/// </summary>
+public class WiperAutoController : MonoBehaviour
+{
+    public static WiperAutoController Instance { get; private set; }
+
+    private const int RAIN_MODE = 2;
+    private const int OFF_MODE = 0;
+    private const int HORI_BUTTON_OFF = 42;
+    private const int HORI_BUTTON_ON = 43;
+
+    private ControllWipers _cachedWipers;
+    private InputDevice _horiWheel;
+    private ButtonControl _btnOff;
+    private ButtonControl _btnOn;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void Bootstrap()
+    {
+        if (Instance != null) return;
+        var go = new GameObject("[WiperAutoController]");
+        DontDestroyOnLoad(go);
+        Instance = go.AddComponent<WiperAutoController>();
+
+        var active = SceneManager.GetActiveScene();
+        if (active.IsValid()) Instance.HandleScene(active);
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode) => HandleScene(scene);
+
+    private void HandleScene(Scene scene)
+    {
+        _cachedWipers = null;
+        if (scene.name == "MainMenu" || scene.name == "Motocicleta") return;
+        StartCoroutine(ApplyAutoMode());
+    }
+
+    private IEnumerator ApplyAutoMode()
+    {
+        // 1-frame retry: ControllWipers a veces se instancia tarde dentro de
+        // jerarquías de prefab del player.
+        var wipers = FindFirstObjectByType<ControllWipers>();
+        if (wipers == null) { yield return null; wipers = FindFirstObjectByType<ControllWipers>(); }
+        if (wipers == null)
+        {
+            Debug.Log("[WiperAutoController] No hay ControllWipers en la escena — skip.");
+            yield break;
+        }
+
+        _cachedWipers = wipers;
+
+        int clima = PlayerPrefs.GetInt("Clima", 0);
+        int targetMode = (clima == 1 || clima == 2) ? RAIN_MODE : OFF_MODE;
+        wipers.SetMode(targetMode);
+        Debug.Log($"[WiperAutoController] Auto-mode: Clima={clima} → wiper mode {targetMode}");
+
+        OverrideWipeKeyboardBinding();
+    }
+
+    private void OverrideWipeKeyboardBinding()
+    {
+        var inputs = FindObjectsByType<PlayerInput>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+        foreach (var pi in inputs)
+        {
+            if (pi == null || pi.actions == null) continue;
+            var wipeAction = pi.actions.FindAction("Wipe", throwIfNotFound: false);
+            if (wipeAction == null) continue;
+            var bindings = wipeAction.bindings;
+            for (int i = 0; i < bindings.Count; i++)
+            {
+                if (bindings[i].path == "<Keyboard>/e")
+                {
+                    wipeAction.ApplyBindingOverride(i, "");
+                    Debug.Log($"[WiperAutoController] Binding <Keyboard>/e en acción Wipe anulado en {pi.name}.");
+                }
+            }
+        }
+    }
+
+    private void Update()
+    {
+        EnsureHoriRefs();
+
+        if (_btnOff != null && _btnOff.wasPressedThisFrame)
+        {
+            GetWipers()?.SetMode(OFF_MODE);
+        }
+        if (_btnOn != null && _btnOn.wasPressedThisFrame)
+        {
+            GetWipers()?.SetMode(RAIN_MODE);
+        }
+    }
+
+    private ControllWipers GetWipers()
+    {
+        if (_cachedWipers != null) return _cachedWipers;
+        _cachedWipers = FindFirstObjectByType<ControllWipers>();
+        return _cachedWipers;
+    }
+
+    private void EnsureHoriRefs()
+    {
+        if (_horiWheel != null && _horiWheel.added && _btnOff != null && _btnOn != null) return;
+
+        _horiWheel = null;
+        _btnOff = null;
+        _btnOn = null;
+
+        foreach (var device in InputSystem.devices)
+        {
+            if (device == null || !device.added) continue;
+            string name = (device.displayName ?? "").ToUpperInvariant();
+            if (!name.Contains("HORI")) continue;
+            if (name.Contains("SHIFTER")) continue;
+
+            _horiWheel = device;
+            _btnOff = device.TryGetChildControl<ButtonControl>("button" + HORI_BUTTON_OFF);
+            _btnOn = device.TryGetChildControl<ButtonControl>("button" + HORI_BUTTON_ON);
+            break;
+        }
+    }
+}

--- a/2026MVP/Assets/Custom/WiperAutoController.cs.meta
+++ b/2026MVP/Assets/Custom/WiperAutoController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e268a9637504867b1d8785692d359d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/WindshieldRainAsset/Common/DemoResources/Scripts/ControllWipers.cs
+++ b/2026MVP/Assets/WindshieldRainAsset/Common/DemoResources/Scripts/ControllWipers.cs
@@ -77,6 +77,17 @@ namespace ShadedTechnology.WindshieldRainAsset.Demo
         }
 #endif
 
+        // Custom (Tlax2026): permite que WiperAutoController.cs maneje el modo
+        // sin pasar por el InputSystem. Si el prefab tiene menos presets de los
+        // pedidos, degrada al máximo disponible en vez de quedar fuera de rango.
+        public void SetMode(int mode)
+        {
+            int max = m_WipingPresets != null ? m_WipingPresets.Length : 0;
+            if (mode < 0) mode = 0;
+            if (mode > max) mode = max;
+            _wiperMode = mode;
+        }
+
         // Update is called once per frame
         void Update()
         {

--- a/2026MVP/CLAUDE.md
+++ b/2026MVP/CLAUDE.md
@@ -120,6 +120,22 @@ Sistema de clima aleatorio (Sol / Lluvia / Granizo). Singleton bootstrapped (`Af
 
 Ver [`WEATHER_SYSTEM.md`](WEATHER_SYSTEM.md) para arquitectura completa, gotchas (`size3D`, `AfterSceneLoad`, `rateOverTimeMultiplier`), demo codes `TTTTXY` y TODOs.
 
+### Wiper Control (`Assets/Custom/WiperAutoController.cs`, v1.3.9)
+
+Singleton bootstrapped (`AfterSceneLoad`, `DontDestroyOnLoad`) que maneja los limpiaparabrisas en escenas con `ControllWipers` (Sedan, Camioneta, Ambulancia, CamionDCarga; agregados en commit `486906e4` "Espejos con wipers"). Tres responsabilidades:
+
+1. **Auto-on por clima**: al cargar escena lee `PlayerPrefs.GetInt("Clima")` y llama `ControllWipers.SetMode(2)` si hay lluvia/granizo, o `SetMode(0)` si sol. El examinado nunca tiene que tocar nada para encender wipers cuando llueve.
+
+2. **Override del binding `<Keyboard>/e`**: el demo del asset `WindshieldRainAsset` tenía `Wipe → <Keyboard>/e`, lo cual chocaba con direccional derecha (`PlayerCar.cs:286` lee `eKey` directo del Keyboard). El controller anula ese binding en runtime con `ApplyBindingOverride(i, "")` — no se modifica el `.inputactions` vendor.
+
+3. **HORI buttons**: polling directo del device (no path strings) — **button42 → wipers OFF**, **button43 → ON latcheado en velocidad media (mode 2)**. Detecta el WHEEL filtrando `displayName.Contains("HORI")` y `!Contains("SHIFTER")`. No usa el sistema de bindings de `UIInputNew` por simplicidad; si en el futuro se quiere remapear, agregar `PREF_BIND_WIPER_ON/OFF` en `UIInputNew` y leer esos paths en lugar de los hardcoded `button42/43`.
+
+**Excluye** `MainMenu` y `Motocicleta` (early return en `HandleScene`).
+
+**Cambio vendor mínimo**: `Assets/WindshieldRainAsset/Common/DemoResources/Scripts/ControllWipers.cs` recibe un método público `SetMode(int)` con clamp defensivo. Si el asset se reimporta limpio, este método se pierde y el `WiperAutoController` falla en compile-time. Re-aplicar el patch tras cualquier upgrade del asset.
+
+**Atajos de teclado (debug)**: `0` = off, `1`/`2`/`3`/`4` = modos 1-4. Heredados del demo, sobreviven al override.
+
 ### Auto-update OTA (`Assets/Custom/AutoUpdater.cs`)
 
 Singleton que vive en `[AutoUpdater]` GameObject (DontDestroyOnLoad). Hardened en 1.2.2 (abr 2026) tras analisis exhaustivo + revision Codex.

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.3.11
+  bundleVersion: 1.3.12
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
## Summary

- Cherry-pick del commit `84541762` que vivía en `feature/wiper-auto-hori` y nunca se mergeó a main (los tags `v1.3.8`/`v1.3.9` apuntan ahí).
- Agrega `WiperAutoController.cs` (singleton AfterSceneLoad, `DontDestroyOnLoad`) con tres comportamientos:
  1. **Auto-on por clima**: lee `PlayerPrefs["Clima"]` al cargar Sedan/Camioneta/Ambulancia/CamionDCarga/BusPasajeros y llama `ControllWipers.SetMode(2)` si Lluvia/Granizo, `SetMode(0)` si Sol.
  2. **Override `<Keyboard>/e`** en la acción `Wipe` del PlayerInput (heredado del demo del asset WindshieldRainAsset). Antes pulsar `E` activaba wiper Y direccional derecha (`PlayerCar.cs:286` lee `eKey` directo).
  3. **HORI HPC-044U**: `button42` → wipers OFF, `button43` → ON latcheado en mode 2. Acceso directo al device cacheado (no path strings — el HORI puede registrarse como Joystick).
- Cambio vendor mínimo en `ControllWipers.cs`: método público `SetMode(int)` con clamp defensivo.
- Bump `bundleVersion` → **1.3.12** (resuelto el conflicto sobre 1.3.11 actual de main).

## Por qué este PR

El usuario reportó que la auto-activación de wipers en lluvia ya no funcionaba en Sedan/Camioneta y los botones 42/43 del HORI tampoco respondían en el camión de pasajeros. La feature **nunca había llegado a main** — vivía sólo en `feature/wiper-auto-hori`. Verificado con Codex (read-only diff de los archivos potencialmente conflictivos).

## Test plan

- [ ] Build local en Unity → verificar que compila sin errores
- [ ] Sedan + Clima=Lluvia → wipers se prenden solos al cargar escena
- [ ] Sedan + Clima=Sol → wipers apagados
- [ ] Cualquier escena de manejo: pulsar `E` ya no activa wipe (solo direccional derecha)
- [ ] BusPasajeros con HORI conectado: button42 apaga wipers, button43 los prende
- [ ] MainMenu y Motocicleta: el controller no interfiere (early return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)