### PR TITLE
chore: bump bundleVersion → 1.4.0

### DIFF
--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.3.12
+  bundleVersion: 1.4.0
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
## Summary

- Bump `bundleVersion` de 1.3.12 a **1.4.0** en `2026MVP/ProjectSettings/ProjectSettings.asset`.
- MINOR bump (no PATCH) para marcar el corte tras los features acumulados desde 1.3.x: wipers auto-on por clima + HORI 42/43 (PR #145), bus door button (PR #144), spawn fixes, autoupdater hardening (PR #141), weather system, etc.

## Despliegue

La build 1.4.0 ya fue publicada al portal admin y desplegada a los 6 SIMs + Emergencia + Carga (todos en 1.4.0 confirmado por heartbeat).

- s3Key: `unity-builds/dev/1.4.0/Tlax2026-RC-v1.4.0.zip`
- sha256: `4ef3d0643471377b563a10f3a8e627891d78f3ce2fdefdb135285f4e93f5450e`
- size: 821 MB

## Test plan

- [x] Build batch compila sin errores (Unity 6, target Win64)
- [x] bundleVersion en el binario coincide con 1.4.0
- [x] OTA install end-to-end en 8 PCs (6 SIM + 2 no-SIM)
- [x] Heartbeat reporta appVersion=1.4.0 tras install

🤖 Generated with [Claude Code](https://claude.com/claude-code)