### PR TITLE
chore(unity6): migrate deprecated APIs + waypoint debug key K→V

### DIFF
--- a/2026MVP/Assets/Custom/HornController.cs
+++ b/2026MVP/Assets/Custom/HornController.cs
@@ -10,7 +10,7 @@ public class HornController : MonoBehaviour
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
     static void AutoCreate()
     {
-        if (FindObjectOfType<HornController>() != null) return;
+        if (FindFirstObjectByType<HornController>() != null) return;
         var go = new GameObject("[HornController]");
         go.AddComponent<HornController>();
         DontDestroyOnLoad(go);
@@ -86,13 +86,13 @@ public class HornController : MonoBehaviour
 
         // UIInputNew vive en el PlayerCar y aparece después del scene load.
         // Reintenta cada 0.5s mientras no esté disponible (evita
-        // FindObjectOfType cada frame, que es lento).
+        // FindFirstObjectByType cada frame, que es lento).
         if (_input == null)
         {
             _inputResolveTimer -= Time.unscaledDeltaTime;
             if (_inputResolveTimer > 0f) return;
             _inputResolveTimer = 0.5f;
-            _input = FindObjectOfType<Gley.UrbanSystem.UIInputNew>();
+            _input = FindFirstObjectByType<Gley.UrbanSystem.UIInputNew>();
             if (_input == null) return;
         }
 

--- a/2026MVP/Assets/Custom/SpawnLocationManager.cs
+++ b/2026MVP/Assets/Custom/SpawnLocationManager.cs
@@ -19,7 +19,7 @@ public static class SpawnLocationManager
     static bool subscribed;
 
     // Índices distribuidos en la red de waypoints de Gley UrbanExample.
-    // Para refinar un slot: maneja a la zona deseada y presiona [K] — log
+    // Para refinar un slot: maneja a la zona deseada y presiona [V] — log
     // en F7 imprime el índice del waypoint más cercano al Player. Cambia
     // el entero correspondiente y rebuildea.
     //   slot 1 = 11111 (legacy)                  slot 2 = 11112 (zona 2)
@@ -208,7 +208,7 @@ internal class SpawnLocationRunner : MonoBehaviour
 }
 
 /// <summary>
-/// Helper de debug: presiona [K] para loggear el índice del waypoint Gley más
+/// Helper de debug: presiona [V] para loggear el índice del waypoint Gley más
 /// cercano al Player. Útil para descubrir qué número poner en
 /// SpawnLocationManager.DEFAULT_WAYPOINTS para una zona específica (glorieta,
 /// escolar, hospital, etc.) sin tener que abrir el editor de Unity.
@@ -218,7 +218,7 @@ internal class WaypointDebugger : MonoBehaviour
     void Update()
     {
         var kb = Keyboard.current;
-        if (kb == null || !kb.kKey.wasPressedThisFrame) return;
+        if (kb == null || !kb.vKey.wasPressedThisFrame) return;
 
         // Defensivo: si se quedó vivo durante un cambio de escena, no toques
         // Gley a menos que la escena actual sea de manejo (whitelist).

--- a/2026MVP/Assets/Custom/SpeedometerSetup.cs
+++ b/2026MVP/Assets/Custom/SpeedometerSetup.cs
@@ -138,7 +138,7 @@ public class SpeedometerSetup : MonoBehaviour
         limitTmp.verticalAlignment = VerticalAlignmentOptions.Middle;
         limitTmp.color = Color.black;
         limitTmp.raycastTarget = false;
-        limitTmp.enableWordWrapping = false;
+        limitTmp.textWrappingMode = TextWrappingModes.NoWrap;
         limitTmp.overflowMode = TextOverflowModes.Overflow;
         limitTmp.enableAutoSizing = true;
         limitTmp.fontSizeMin = 18f;

--- a/2026MVP/Assets/Custom/TopHudRow.cs
+++ b/2026MVP/Assets/Custom/TopHudRow.cs
@@ -204,7 +204,7 @@ public class TopHudRow : MonoBehaviour
         tmp.raycastTarget = false;
         // Sin wrap + auto-size: límites de 3 dígitos (110, 120) se escalan en una sola
         // línea en vez de partirse en "11" / "0".
-        tmp.enableWordWrapping = false;
+        tmp.textWrappingMode = TextWrappingModes.NoWrap;
         tmp.overflowMode = TextOverflowModes.Overflow;
         tmp.enableAutoSizing = true;
         tmp.fontSizeMin = 32f;

--- a/2026MVP/Assets/pruebas general/LevantaMoto.cs
+++ b/2026MVP/Assets/pruebas general/LevantaMoto.cs
@@ -2,11 +2,10 @@ using UnityEngine;
 
 public class LevantaMoto : MonoBehaviour
 {
-    [Header("Configuración")]
+    [Header("Configuraciï¿½n")]
     public float rotationThreshold = 80f;  
     public float delayBeforeReset = 5f;    
 
-    private bool isCounting = false;
     private float timer = 0f;
 
     void Update()
@@ -19,7 +18,7 @@ public class LevantaMoto : MonoBehaviour
 
             if (timer >= delayBeforeReset)
             {
-                // Reset súbito a 0 en Z
+                // Reset sï¿½bito a 0 en Z
                 transform.eulerAngles = new Vector3(
                     transform.eulerAngles.x,
                     transform.eulerAngles.y,


### PR DESCRIPTION
## Summary

Auto-fixes que Unity 6 sugiere al abrir el proyecto + un cambio menor de atajo de debug.

### Migrations puras (mismo comportamiento)
- `FindObjectOfType` → `FindFirstObjectByType` en `HornController.cs` (3 lugares)
- `enableWordWrapping = false` → `textWrappingMode = TextWrappingModes.NoWrap` en `TopHudRow.cs` y `SpeedometerSetup.cs`
- `LevantaMoto.cs`: eliminar campo no usado `isCounting`

### Cambio funcional (heads-up)
- `SpawnLocationManager.cs`: el `WaypointDebugger` ahora se dispara con **`V`** en vez de `K`. Si fue accidental me avisás y lo reverteo.

## Por qué este PR

Estos cambios estaban en working tree desde antes del build 1.4.0 — Unity los aplicó al compilar la build batch. Ya viven en el binario deployado a los 8 PCs. Este PR los materializa en git para que el árbol de main quede alineado con lo que efectivamente se está corriendo en producción.

## Test plan

- [ ] Build local en Unity → compila sin errores
- [ ] Pulsar `V` en una escena de manejo (Sedan/Camioneta/etc) — log `[WaypointDebug] ... idx=NNN` debe aparecer en consola
- [ ] Pulsar `K` — ya NO debe loggear nada (era el atajo viejo)
- [ ] Verificar que HUD `TopHudRow` y `SpeedometerSetup` siguen mostrando límite de velocidad sin word-wrapping cortado

🤖 Generated with [Claude Code](https://claude.com/claude-code)