### PR TITLE
feat(hori): modo manual con H-shifter + Phase 6 CLUTCH Discovery

### DIFF
--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -157,6 +157,12 @@ public class MenuScreenManager : MonoBehaviour
     private bool rightDone, leftDone;
     private bool throttleDone, brakeDone;
     private bool reverseDone;
+    // Clutch phase: solo aplica si TransmisionManual==1 && IsHORITruck.
+    // En G923 PS el clutch se hardcodea en EnsureG923PSDefaults; en Xbox
+    // y automático no hay clutch. Por eso clutchDone arranca en true para
+    // todos los demás casos y la fase ni se ejecuta.
+    private bool clutchDone = true;
+    private int _brakeChosenIdx = -1; // persistido para excluir en Phase 6
     private Button skipButton;
     private Button reassignButton;
     // Coroutine del sanity check del estado Verified (splash "Preparando
@@ -1820,6 +1826,7 @@ public class MenuScreenManager : MonoBehaviour
             PlayerPrefs.Save();
             // Marcar todas las fases como completadas (visual feedback verde).
             rightDone = leftDone = throttleDone = brakeDone = reverseDone = true;
+            clutchDone = true; // Moto: sin clutch físico.
             steerCenter = 0f; steerMaxSeen = 1f; steerMinSeen = -1f; steerCenterCaptured = true;
             rightIndicator.color = leftIndicator.color = gasIndicator.color =
                 brakeIndicator.color = reverseIndicator.color = MenuTheme.IndicatorDone;
@@ -1847,6 +1854,7 @@ public class MenuScreenManager : MonoBehaviour
             PlayerPrefs.Save();
             // Marcar todas las fases como completadas para que la UI muestre verde.
             rightDone = leftDone = throttleDone = brakeDone = reverseDone = true;
+            clutchDone = true; // G923 PS: clutch hardcoded en EnsureG923PSDefaults. Xbox: sin clutch.
             steerCenter = 0f; steerMaxSeen = 1f; steerMinSeen = -1f; steerCenterCaptured = true;
             // UI: indicadores y fills en estado "done".
             rightIndicator.color = leftIndicator.color = gasIndicator.color =
@@ -1889,14 +1897,54 @@ public class MenuScreenManager : MonoBehaviour
             && PlayerPrefs.HasKey("G923_BrakeAxis") && PlayerPrefs.HasKey("G923_BrakeRest") && PlayerPrefs.HasKey("G923_BrakePress");
         bool reverseCal = fingerprintMatches && PlayerPrefs.GetInt(PREF_CAL_REVERSE_DONE, 0) == 1;
 
+        // Clutch phase: solo HORI + Manual + sin clutch axis válido. G923 PS
+        // setea G923_ClutchAxis="stick/y" en EnsureG923PSDefaults (fast-path
+        // arriba); G923 Xbox no tiene clutch físico; HORI en automático no
+        // necesita clutch — para todos esos casos clutchPhaseNeeded=false.
+        // El axis del clutch HORI no se puede hardcodear porque Unity alias
+        // slider/slider1/rz arbitrariamente entre brake y clutch (ver
+        // HORI_THROTTLE_BUG_RESOLUTION.md). Por eso lo descubrimos pisando.
+        bool clutchAlreadyCal = fingerprintMatches
+            && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_AXIS)
+            && !string.IsNullOrEmpty(PlayerPrefs.GetString(UIInputNew.PREF_G923_CLUTCH_AXIS, ""))
+            && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_REST)
+            && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_PRESS);
+        bool clutchPhaseNeeded = PlayerPrefs.GetInt("TransmisionManual", 0) == 1
+            && dev != null && UIInputNew.IsHORITruck(dev) && !clutchAlreadyCal;
+
         rightDone = leftDone = steeringCal;
         throttleDone = brakeDone = pedalsCal;
         reverseDone = reverseCal;
+        clutchDone = !clutchPhaseNeeded;
+        _brakeChosenIdx = -1; // se llenará en la phase brake (Update)
 
         // Reset deltas de candidatos para esta sesión de calibración
         if (pedalCandidateMaxDeltas != null)
             for (int i = 0; i < pedalCandidateMaxDeltas.Length; i++) pedalCandidateMaxDeltas[i] = 0f;
         gasChosenIdx = -1;
+
+        // Si los pedales ya están calibrados (pedalsCal) pero la Phase 6
+        // (CLUTCH) sí necesita correr, recuperamos los índices de gas y
+        // brake desde los paths persistidos para excluirlos correctamente
+        // en SamplePedalCandidates(gasIdx, brakeIdx, ...). Además, cuando
+        // se salta phases 3/4 hay que cachear los candidatos manualmente
+        // — Phase 3 normalmente llama CachePedalCandidates+SnapshotPedalRests
+        // pero si pedalsCal=true no se ejecuta y Phase 6 quedaría sin datos.
+        if (pedalsCal)
+        {
+            string savedGas   = PlayerPrefs.GetString("G923_GasAxis", "");
+            string savedBrake = PlayerPrefs.GetString("G923_BrakeAxis", "");
+            for (int i = 0; i < PEDAL_AXIS_CANDIDATES.Length; i++)
+            {
+                if (gasChosenIdx == -1   && PEDAL_AXIS_CANDIDATES[i] == savedGas)   gasChosenIdx = i;
+                if (_brakeChosenIdx == -1 && PEDAL_AXIS_CANDIDATES[i] == savedBrake) _brakeChosenIdx = i;
+            }
+            if (clutchPhaseNeeded && dev != null)
+            {
+                CachePedalCandidates(dev);
+                SnapshotPedalRests();
+            }
+        }
 
         // Reset descubrimiento del eje del volante. Snapshot se hace en
         // Update al entrar a fase 1 (el usuario ya tiene las manos puestas).
@@ -1938,7 +1986,7 @@ public class MenuScreenManager : MonoBehaviour
         reverseFill.color = reverseDone ? MenuTheme.IndicatorDone : MenuTheme.SecondaryCrimson;
 
         // ── 3) Decidir el modo de la pantalla ──
-        bool fullyCalibrated = steeringCal && pedalsCal && reverseCal;
+        bool fullyCalibrated = steeringCal && pedalsCal && reverseCal && !clutchPhaseNeeded;
 
         if (fullyCalibrated)
         {
@@ -1951,10 +1999,14 @@ public class MenuScreenManager : MonoBehaviour
         else
         {
             // Discovery / Partial: prompt según primera fase pendiente.
+            // Phase 6 (CLUTCH) corre entre brake y reverse: solo cuando aplica
+            // (HORI + Manual sin clutch axis previo). En el resto de los casos
+            // clutchDone=true desde el inicio y la fase nunca se ve.
             wheelPrompt.text = !rightDone    ? "Gira el volante hacia la DERECHA"
                              : !leftDone     ? "Gira el volante hacia la IZQUIERDA"
                              : !throttleDone ? "Pisa el ACELERADOR a fondo"
                              : !brakeDone    ? "Pisa el FRENO a fondo"
+                             : !clutchDone   ? "Pisa el EMBRAGUE a fondo"
                              :                 "Activa la REVERSA";
             if (skipButton != null) skipButton.gameObject.SetActive(true);
             if (reassignButton != null) reassignButton.gameObject.SetActive(false);
@@ -2006,7 +2058,7 @@ public class MenuScreenManager : MonoBehaviour
         if (steer > steerMaxSeen) steerMaxSeen = steer;
         if (steer < steerMinSeen) steerMinSeen = steer;
 
-        if (rightDone && leftDone && throttleDone && brakeDone && reverseDone) return;
+        if (rightDone && leftDone && throttleDone && brakeDone && clutchDone && reverseDone) return;
 
         if (!rightDone)
         {
@@ -2205,6 +2257,7 @@ public class MenuScreenManager : MonoBehaviour
             if (bestAbsDelta >= PEDAL_DELTA_THRESHOLD && bestIdx >= 0)
             {
                 brakeDone = true;
+                _brakeChosenIdx = bestIdx; // Phase 6 (clutch) lo excluye.
                 float rest = pedalCandidateRests[bestIdx];
                 float press = rest + pedalCandidateMaxDeltas[bestIdx];
                 string brakeAxisPath = PEDAL_AXIS_CANDIDATES[bestIdx];
@@ -2223,7 +2276,22 @@ public class MenuScreenManager : MonoBehaviour
                 PlayerPrefs.Save();
                 Debug.Log($"[MenuScreenManager] Freno → eje '{brakeAxisPath}' rest={rest:F3} press={press:F3} fp={fpBrake}");
 
-                if (reverseDone)
+                // Encadenar próxima fase: clutch (HORI manual) → reverse → load.
+                if (!clutchDone)
+                {
+                    // Resetear deltas de los candidatos para la fase clutch
+                    // (los deltas acumulados durante brake quedarían como
+                    // "press" del clutch — phantom positives).
+                    if (pedalCandidateMaxDeltas != null)
+                        for (int i = 0; i < pedalCandidateMaxDeltas.Length; i++) pedalCandidateMaxDeltas[i] = 0f;
+                    SnapshotPedalRests();
+                    wheelPrompt.text = "Pisa el EMBRAGUE a fondo";
+                    // brakeFill queda como progress visual del clutch (reusado).
+                    brakeFillRT.anchorMax = new Vector2(0, 1);
+                    brakeFill.color = MenuTheme.SecondaryCrimson;
+                    brakeIndicator.color = MenuTheme.IndicatorPending;
+                }
+                else if (reverseDone)
                 {
                     wheelPrompt.text = "Cargando prueba...";
                     skipButton.gameObject.SetActive(false);
@@ -2239,6 +2307,55 @@ public class MenuScreenManager : MonoBehaviour
             {
                 brakeFillRT.anchorMax = new Vector2(brakeProgress, 1);
                 brakeFill.color = Color.Lerp(MenuTheme.SecondaryCrimson, MenuTheme.IndicatorDone, brakeProgress);
+            }
+            return;
+        }
+
+        // ── Fase 6: calibración dinámica del EMBRAGUE (HORI manual only) ──
+        // Reusa la barra brakeFill como feedback visual (sin agregar UI nueva).
+        // Excluye gas y brake; el axis del clutch HORI es el slider/slider1/rz
+        // restante que reaccione al pedal físico de embrague. Ver
+        // HORI_THROTTLE_BUG_RESOLUTION.md sobre por qué no se hardcodea.
+        if (!clutchDone)
+        {
+            int bestIdx = SamplePedalCandidates(gasChosenIdx, _brakeChosenIdx, out float bestAbsDelta);
+            float clutchProgress = Mathf.Clamp01(bestAbsDelta);
+
+            if (bestAbsDelta >= PEDAL_DELTA_THRESHOLD && bestIdx >= 0)
+            {
+                clutchDone = true;
+                float rest = pedalCandidateRests[bestIdx];
+                float press = rest + pedalCandidateMaxDeltas[bestIdx];
+                string clutchAxisPath = PEDAL_AXIS_CANDIDATES[bestIdx];
+
+                brakeFillRT.anchorMax = new Vector2(1, 1);
+                brakeFill.color = MenuTheme.IndicatorDone;
+                brakeIndicator.color = MenuTheme.IndicatorDone;
+
+                PlayerPrefs.SetString(UIInputNew.PREF_G923_CLUTCH_AXIS, clutchAxisPath);
+                PlayerPrefs.SetFloat(UIInputNew.PREF_G923_CLUTCH_REST, rest);
+                PlayerPrefs.SetFloat(UIInputNew.PREF_G923_CLUTCH_PRESS, press);
+                string fpClutch = ComputeDeviceFingerprint(TryAttachToDevice());
+                if (!string.IsNullOrEmpty(fpClutch)) PlayerPrefs.SetString(PREF_CAL_FINGERPRINT, fpClutch);
+                PlayerPrefs.Save();
+                Debug.Log($"[MenuScreenManager] Embrague → eje '{clutchAxisPath}' rest={rest:F3} press={press:F3} fp={fpClutch}");
+
+                if (reverseDone)
+                {
+                    wheelPrompt.text = "Cargando prueba...";
+                    skipButton.gameObject.SetActive(false);
+                    StartCoroutine(LoadSceneDelayed(1.5f));
+                }
+                else
+                {
+                    SnapshotReverseBaseline();
+                    wheelPrompt.text = "Activa la REVERSA";
+                }
+            }
+            else if (Mathf.Abs(clutchProgress - brakeFillRT.anchorMax.x) > 0.005f)
+            {
+                brakeFillRT.anchorMax = new Vector2(clutchProgress, 1);
+                brakeFill.color = Color.Lerp(MenuTheme.SecondaryCrimson, MenuTheme.IndicatorDone, clutchProgress);
             }
             return;
         }
@@ -2326,6 +2443,10 @@ public class MenuScreenManager : MonoBehaviour
     // Además se excluye el eje del volante (_steerExcludedPedalIdx) si éste
     // coincide con uno de los candidatos de pedal.
     int SamplePedalCandidates(int excludeIdx, out float bestAbsDelta)
+        => SamplePedalCandidates(excludeIdx, -1, out bestAbsDelta);
+
+    // Overload para Phase 6 (CLUTCH): excluye gas + brake + steer simultáneamente.
+    int SamplePedalCandidates(int excludeIdx1, int excludeIdx2, out float bestAbsDelta)
     {
         bestAbsDelta = 0f;
         int bestIdx = -1;
@@ -2337,7 +2458,7 @@ public class MenuScreenManager : MonoBehaviour
             float delta = v - pedalCandidateRests[i];
             if (Mathf.Abs(delta) > Mathf.Abs(pedalCandidateMaxDeltas[i]))
                 pedalCandidateMaxDeltas[i] = delta; // preserva signo
-            if (i == excludeIdx || i == _steerExcludedPedalIdx) continue;
+            if (i == excludeIdx1 || i == excludeIdx2 || i == _steerExcludedPedalIdx) continue;
             float absD = Mathf.Abs(pedalCandidateMaxDeltas[i]);
             if (absD > bestAbsDelta) { bestAbsDelta = absD; bestIdx = i; }
         }
@@ -2670,6 +2791,16 @@ public class MenuScreenManager : MonoBehaviour
         // los conservamos, un wheel nuevo intentaría leer del path viejo.
         PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_STEER_AXIS);
         PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_REVERSE);
+        // H-shifter gears: si quedaron paths "shifter:*" del HORI y ahora se
+        // calibra otro hardware (G923 sin shifter), esos paths no resuelven y
+        // dejarían el modo manual roto. Limpiar siempre que el operador pida
+        // "Reasignar controles" para empezar slate limpio.
+        PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_GEAR1);
+        PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_GEAR2);
+        PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_GEAR3);
+        PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_GEAR4);
+        PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_GEAR5);
+        PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_GEAR6);
         PlayerPrefs.Save();
     }
 
@@ -2694,14 +2825,24 @@ public class MenuScreenManager : MonoBehaviour
         InputDevice dev = TryAttachToDevice();
         string gasPath = PlayerPrefs.GetString("G923_GasAxis", "");
         string brakePath = PlayerPrefs.GetString("G923_BrakeAxis", "");
-        InputControl<float> gasC = (dev != null && !string.IsNullOrEmpty(gasPath))
+
+        // El throttle del HORI no es un Unity InputControl: es el sentinel
+        // HORI_RAW_GAS_PATH y se lee vía P/Invoke en HoriThrottleReader.
+        // TryGetChildControl(sentinel) siempre devuelve null, lo que invalidaba
+        // toda la calibración del HORI cada vez que se entraba al splash.
+        // Bug encontrado por Codex review 2026-05-06.
+        bool gasIsHoriRaw = gasPath == UIInputNew.HORI_RAW_GAS_PATH;
+        InputControl<float> gasC = (dev != null && !gasIsHoriRaw && !string.IsNullOrEmpty(gasPath))
             ? dev.TryGetChildControl(gasPath) as InputControl<float> : null;
         InputControl<float> brakeC = (dev != null && !string.IsNullOrEmpty(brakePath))
             ? dev.TryGetChildControl(brakePath) as InputControl<float> : null;
 
         // Si el axis previamente calibrado ya no existe en el device, la
-        // calibración no sirve — degradar a discovery.
-        if (dev != null && (gasC == null || brakeC == null))
+        // calibración no sirve — degradar a discovery. Para HORI, el gas
+        // (sentinel) cuenta como "OK" si el bypass está activo (HoriThrottle-
+        // Reader cargado) — solo degradamos si el brake no resuelve.
+        bool gasOk = gasIsHoriRaw || gasC != null;
+        if (dev != null && (!gasOk || brakeC == null))
         {
             Debug.Log("[MenuScreenManager] Sanity check: axis previamente calibrado no existe en el device → discovery");
             ClearWheelCalibration();
@@ -2709,23 +2850,68 @@ public class MenuScreenManager : MonoBehaviour
             yield break;
         }
 
-        // Clutch: solo valido en modo manual y si hay path guardado (G923 PS).
-        // En Xbox y modo Auto el clutch no se evalúa — el axis no debería ser
-        // requisito para arrancar.
+        // Buscar shifter device para validación multi-device de paths
+        // "shifter:*" (HORI). Si no existe shifter pero hay binds shifter:*
+        // persistidos, esos binds son huérfanos (cambio de hardware).
+        InputDevice shifterDev = null;
+        foreach (var d in InputSystem.devices)
+        {
+            if (d == dev) continue;
+            if (UIInputNew.IsShifterDevice(d)) { shifterDev = d; break; }
+        }
+
+        // Clutch: solo valido en modo manual y si hay path guardado (G923 PS
+        // o HORI con clutch descubierto). En Xbox y modo Auto el clutch no se
+        // evalúa — el axis no debería ser requisito para arrancar.
         bool needClutch = PlayerPrefs.GetInt("TransmisionManual", 0) == 1
                        && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_AXIS);
         string clutchPath = PlayerPrefs.GetString(UIInputNew.PREF_G923_CLUTCH_AXIS, "");
-        InputControl<float> clutchC = (needClutch && dev != null && !string.IsNullOrEmpty(clutchPath))
-            ? dev.TryGetChildControl(clutchPath) as InputControl<float> : null;
+        // Resolver con multi-device (wheel + shifter) para soportar paths
+        // tipo "shifter:slider" si el clutch está en el SHIFTER device.
+        InputControl<float> clutchC = needClutch
+            ? UIInputNew.ResolveControlPathFor(dev, shifterDev, clutchPath)
+            : null;
         if (needClutch && dev != null && clutchC == null)
         {
-            Debug.Log("[MenuScreenManager] Sanity check: axis de clutch calibrado no existe en el device → limpiar prefs de clutch (modo manual seguirá sin desacople)");
+            Debug.Log("[MenuScreenManager] Sanity check: axis de clutch calibrado no resuelve (wheel+shifter) → limpiar prefs de clutch (modo manual seguirá sin desacople)");
             PlayerPrefs.DeleteKey(UIInputNew.PREF_G923_CLUTCH_AXIS);
             PlayerPrefs.DeleteKey(UIInputNew.PREF_G923_CLUTCH_REST);
             PlayerPrefs.DeleteKey(UIInputNew.PREF_G923_CLUTCH_PRESS);
             PlayerPrefs.Save();
             // No degradamos a discovery por esto — el manual sin clutch funciona
             // (modo didáctico). El operador puede recalibrar via Pantalla 2.
+        }
+
+        // Bind_gear1..6 + Bind_reverse: si alguno tiene prefijo "shifter:"
+        // pero no hay shifter device, los binds quedaron huérfanos (cambio
+        // HORI→G923 o desconexión del shifter). Limpiar todos para que
+        // ReCacheGearControls caiga al fallback legacy 13-19 del G923.
+        string[] gearKeys = {
+            UIInputNew.PREF_BIND_GEAR1, UIInputNew.PREF_BIND_GEAR2,
+            UIInputNew.PREF_BIND_GEAR3, UIInputNew.PREF_BIND_GEAR4,
+            UIInputNew.PREF_BIND_GEAR5, UIInputNew.PREF_BIND_GEAR6,
+            UIInputNew.PREF_BIND_REVERSE
+        };
+        bool anyShifterOrphan = false;
+        foreach (var key in gearKeys)
+        {
+            string p = PlayerPrefs.GetString(key, "");
+            if (string.IsNullOrEmpty(p)) continue;
+            if (!p.StartsWith("shifter:", System.StringComparison.Ordinal)) continue;
+            if (shifterDev == null
+                || !UIInputNew.ResolvePathExists(dev, shifterDev, p))
+            {
+                anyShifterOrphan = true;
+                break;
+            }
+        }
+        if (anyShifterOrphan)
+        {
+            Debug.Log("[MenuScreenManager] Sanity check: Bind_gear*/Bind_reverse contienen 'shifter:' huérfanos (sin shifter device o path no resuelve) → limpiar para volver a defaults del hardware actual");
+            for (int i = 0; i < 6; i++)
+                PlayerPrefs.DeleteKey(gearKeys[i]);
+            PlayerPrefs.DeleteKey(UIInputNew.PREF_BIND_REVERSE);
+            PlayerPrefs.Save();
         }
 
         float gasRest = PlayerPrefs.GetFloat("G923_GasRest", 0f);

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/Example/PlayerCar.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/Example/PlayerCar.cs
@@ -185,8 +185,8 @@ namespace Gley.UrbanSystem
         [Tooltip("Velocidad mínima útil por marcha (km/h). Index 0=N, 1-6. Bajo este valor el motor 'lugger': torque cae cuadráticamente. 1ra debe ser 0 para arrancar.")]
         public float[] gearMinSpeedKmh = { 0f, 0f, 15f, 30f, 50f, 75f, 100f };
 
-        [Tooltip("Velocidad máxima alcanzable por marcha (km/h). Index 0=N, 1-6.")]
-        public float[] gearMaxSpeedKmh = { 0f, 25f, 45f, 70f, 100f, 130f, 160f };
+        [Tooltip("Velocidad máxima alcanzable por marcha (km/h). Index 0=N, 1-6. 6ta=180 da headroom sobre el límite legal de 110 km/h en autopista para que el examinado pueda excederse y disparar penalización.")]
+        public float[] gearMaxSpeedKmh = { 0f, 25f, 45f, 70f, 100f, 130f, 180f };
 
         // Gear actual: 0=N, 1-6, -1=R — leido por SimpleSpeedGauge
         [HideInInspector] public int currentGear = 0;

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -438,6 +438,21 @@ namespace Gley.UrbanSystem
                 ctrls.Add(c);
                 vals.Add(i + 1);
             }
+
+            // Si NINGÚN bind resolvió en el hardware actual, los prefs son
+            // huérfanos (ej. usuario calibró HORI con shifter:button1..6 y
+            // ahora conecta G923 sin recalibrar). Caer al legacy 13-19 para
+            // que el modo manual del G923 siga funcionando — el operador
+            // puede recalibrar via F8 o Pantalla 2 cuando quiera.
+            if (ctrls.Count == 0)
+            {
+                Debug.LogWarning("[UIInputNew] Bind_gear* configurados pero ningún path resuelve en este device — fallback legacy buttons 13-19");
+                _gearControls = new InputControl<float>[7];
+                for (int i = 0; i < 7; i++) _gearControls[i] = CacheButton(13 + i);
+                _gearValues = new int[] { 1, 2, 3, 4, 5, 6, -1 };
+                return;
+            }
+
             _gearControls = ctrls.ToArray();
             _gearValues = vals.ToArray();
         }
@@ -899,6 +914,39 @@ namespace Gley.UrbanSystem
             return hasShifter && !hasWheel;
         }
 
+        // Helper para que MenuScreenManager (sanity check) valide o resuelva
+        // paths con prefijos "wheel:"/"shifter:" sin replicar la lógica de
+        // ResolveControlPath. Devuelve el control si existe; null si no.
+        // Sin prefijo: prueba wheel primero, fallback shifter (mismo orden
+        // que el ResolveControlPath de instancia).
+        public static InputControl<float> ResolveControlPathFor(InputDevice wheel, InputDevice shifter, string path)
+        {
+            if (string.IsNullOrEmpty(path)) return null;
+            const string WHEEL_PREFIX = "wheel:";
+            const string SHIFTER_PREFIX = "shifter:";
+            if (path.StartsWith(WHEEL_PREFIX, System.StringComparison.Ordinal))
+            {
+                if (wheel == null || !wheel.added) return null;
+                return wheel.TryGetChildControl(path.Substring(WHEEL_PREFIX.Length)) as InputControl<float>;
+            }
+            if (path.StartsWith(SHIFTER_PREFIX, System.StringComparison.Ordinal))
+            {
+                if (shifter == null || !shifter.added) return null;
+                return shifter.TryGetChildControl(path.Substring(SHIFTER_PREFIX.Length)) as InputControl<float>;
+            }
+            if (wheel != null && wheel.added)
+            {
+                var c = wheel.TryGetChildControl(path) as InputControl<float>;
+                if (c != null) return c;
+            }
+            if (shifter != null && shifter.added)
+                return shifter.TryGetChildControl(path) as InputControl<float>;
+            return null;
+        }
+
+        public static bool ResolvePathExists(InputDevice wheel, InputDevice shifter, string path)
+            => ResolveControlPathFor(wheel, shifter, path) != null;
+
         // Mapeo G923 conocido por modo. El switch físico del G923 (PS/Xbox)
         // cambia el HID layout — diferentes axes y buttons exponen las mismas
         // funciones físicas. Detectamos por displayName y aplicamos defaults
@@ -1020,16 +1068,43 @@ namespace Gley.UrbanSystem
             //   throttle bypass NO.
             if (IsHORITruck(device))
             {
-                Debug.Log("[UIInputNew] HORI Truck detectado — defaults paddle/hazard/horn/reverse + throttle vía HoriThrottleReader (raw HID byte intercept)");
-                PlayerPrefs.SetString(PREF_BIND_PADDLE_LEFT, "button40");
-                PlayerPrefs.SetString(PREF_BIND_PADDLE_RIGHT, "button41");
-                PlayerPrefs.SetString(PREF_BIND_HAZARD, "shifter:button27");
-                PlayerPrefs.SetString(PREF_BIND_HORN, "wheel:button7");
-                PlayerPrefs.SetString(PREF_BIND_REVERSE, "shifter:button7");
-                // Puerta del bus: solo asignar si no hay valor previo (no pisar
-                // remapeo del operador en F8). Default wheel:button21.
+                Debug.Log("[UIInputNew] HORI Truck detectado — defaults paddle/hazard/horn/reverse + H-shifter + throttle vía HoriThrottleReader (raw HID byte intercept)");
+                // Botones: solo escribir si no hay valor previo. Esto deja
+                // sobrevivir las reasignaciones F8 entre re-attaches (boot,
+                // reconectar USB). Si se cambia de hardware, el flujo
+                // "Reasignar controles" en Pantalla 2 limpia los binds
+                // explícitamente vía ClearWheelCalibration().
+                if (!PlayerPrefs.HasKey(PREF_BIND_PADDLE_LEFT))
+                    PlayerPrefs.SetString(PREF_BIND_PADDLE_LEFT, "button40");
+                if (!PlayerPrefs.HasKey(PREF_BIND_PADDLE_RIGHT))
+                    PlayerPrefs.SetString(PREF_BIND_PADDLE_RIGHT, "button41");
+                if (!PlayerPrefs.HasKey(PREF_BIND_HAZARD))
+                    PlayerPrefs.SetString(PREF_BIND_HAZARD, "shifter:button27");
+                if (!PlayerPrefs.HasKey(PREF_BIND_HORN))
+                    PlayerPrefs.SetString(PREF_BIND_HORN, "wheel:button7");
+                if (!PlayerPrefs.HasKey(PREF_BIND_REVERSE))
+                    PlayerPrefs.SetString(PREF_BIND_REVERSE, "shifter:button7");
                 if (!PlayerPrefs.HasKey(PREF_BIND_DOOR))
                     PlayerPrefs.SetString(PREF_BIND_DOOR, "wheel:button21");
+                // H-shifter HORI: 6 marchas físicas en el SHIFTER device.
+                // Mapping verificado en F7 con HORI conectado (2026-05-06):
+                //   1ª = "trigger" (Unity nombra el control así por el HID
+                //        usage del HORI, NO es "button1"),
+                //   2ª..6ª = button2..6,
+                //   R = button7 (ya cubierto en PREF_BIND_REVERSE).
+                // Idempotente: si el operador reasigna en F8, sobrevive.
+                if (!PlayerPrefs.HasKey(PREF_BIND_GEAR1))
+                    PlayerPrefs.SetString(PREF_BIND_GEAR1, "shifter:trigger");
+                if (!PlayerPrefs.HasKey(PREF_BIND_GEAR2))
+                    PlayerPrefs.SetString(PREF_BIND_GEAR2, "shifter:button2");
+                if (!PlayerPrefs.HasKey(PREF_BIND_GEAR3))
+                    PlayerPrefs.SetString(PREF_BIND_GEAR3, "shifter:button3");
+                if (!PlayerPrefs.HasKey(PREF_BIND_GEAR4))
+                    PlayerPrefs.SetString(PREF_BIND_GEAR4, "shifter:button4");
+                if (!PlayerPrefs.HasKey(PREF_BIND_GEAR5))
+                    PlayerPrefs.SetString(PREF_BIND_GEAR5, "shifter:button5");
+                if (!PlayerPrefs.HasKey(PREF_BIND_GEAR6))
+                    PlayerPrefs.SetString(PREF_BIND_GEAR6, "shifter:button6");
                 // Throttle: el HID parser de Unity tiene un bug con el descriptor
                 // del HORI HPC-044U (sliders aliased al mismo byte) y deja el
                 // byte del throttle (21-22 del input report) huérfano — ningún
@@ -1037,13 +1112,15 @@ namespace Gley.UrbanSystem
                 // Custom/) intercepta los state events del wheel via InputSystem.
                 // onEvent y lee el byte directo. UIInputNew detecta este path
                 // sentinel y bypass el _gasCtrl read normal.
+                // ⚠️ INCONDICIONAL — sin esto el throttle queda muerto.
                 PlayerPrefs.SetString("G923_GasAxis", HORI_RAW_GAS_PATH);
                 PlayerPrefs.SetFloat("G923_GasRest",   0f);
                 PlayerPrefs.SetFloat("G923_GasPress",  1f);
                 _useHoriRawGas = true;
                 // Brake y clutch SÍ se leen via Unity (slider/slider1/rz aliased
                 // pero al menos brake y clutch responden a sus respectivos
-                // pedales). Discovery los descubre en Pantalla 2.
+                // pedales). Discovery los descubre en Pantalla 2 (clutch tiene
+                // fase dedicada solo si TransmisionManual==1).
                 PlayerPrefs.Save();
             }
             #endregion

--- a/2026MVP/CLAUDE.md
+++ b/2026MVP/CLAUDE.md
@@ -494,7 +494,7 @@ Ver `PLAN_HORI_TRUCK.md` para documentacion completa.
 - **Deteccion:** `UIInputNew.IsHORITruck()` por displayName/product que contenga "HORI"
 - **Defaults automaticos** en `AttachToWheelDevice()` al detectar HORI (no usa `EnsureG923PSDefaults`)
 
-### Mapping verificado (F7, 2026-04-29)
+### Mapping verificado (F7, 2026-05-06)
 
 | Funcion | Path | Device | Reposo |
 |---------|------|--------|--------|
@@ -503,14 +503,26 @@ Ver `PLAN_HORI_TRUCK.md` para documentacion completa.
 | Direccional der | `button41` | WHEEL | — |
 | Intermitentes | `shifter:button27` | SHIFTER | — |
 | Reversa | `shifter:button7` | SHIFTER | — |
+| H-shifter 1ª | `shifter:trigger` | SHIFTER | — |
+| H-shifter 2ª | `shifter:button2` | SHIFTER | — |
+| H-shifter 3ª | `shifter:button3` | SHIFTER | — |
+| H-shifter 4ª | `shifter:button4` | SHIFTER | — |
+| H-shifter 5ª | `shifter:button5` | SHIFTER | — |
+| H-shifter 6ª | `shifter:button6` | SHIFTER | — |
 
 - **Pedales**: descubiertos por Pantalla 2 Discovery (`slider`/`slider1` agregados a `PEDAL_AXIS_CANDIDATES`)
 - **Intermitentes**: binding dedicado `Bind_hazard` (G923 usa combo L1+R1, HORI tiene boton fisico)
 - **Steering**: descubierto dinamicamente por Pantalla 2 (no verificado el eje exacto)
+- **H-shifter**: Unity nombra la 1ª como `trigger` (no `button1`) por HID usage especial. Defaults idempotentes en `AttachToWheelDevice` (sobreviven reasignaciones F8). Ver `PLAN_HORI_TRUCK.md` sección "Modo manual".
+
+### Modo manual + clutch
+- Funcional desde 2026-05-06. `Bind_gear1..6` y `Bind_reverse` defaults idempotentes en `AttachToWheelDevice` cuando se detecta HORI.
+- **Clutch axis**: Discovery dinámico (Phase 6) en Pantalla 2 condicional a `TransmisionManual==1 && IsHORITruck`. NO hardcoded — Unity alias slider/slider1/rz arbitrariamente entre brake y clutch (ver `HORI_THROTTLE_BUG_RESOLUTION.md:170-171`).
+- Detección de "rechino" funciona igual que G923 PS (mismo edge-trigger en `UIInputNew`, mismo gating con `HasPhysicalClutch()` en `ViolationDetector`).
+- **Cambio HORI→G923 sin recalibrar**: `ReCacheGearControls` cae al fallback legacy 13-19 si los paths `shifter:*` no resuelven; `SanityCheckThenLoad` adicionalmente limpia binds huérfanos.
 
 ### Pendiente
-- Mapear marchas H-shifter (buttons en SHIFTER device)
-- Verificar force feedback
+- Verificar force feedback (HORI no tiene FFB — `LogitechFFB.cs` no-op)
 
 ## Build
 

--- a/2026MVP/PLAN_HORI_TRUCK.md
+++ b/2026MVP/PLAN_HORI_TRUCK.md
@@ -41,6 +41,22 @@ Los 3 pedales tienen rest=-1.0 y press hacia +1.0 (inverso al G923 que tiene res
 | `button27` | SHIFTER | Intermitentes (hazard) |
 | `button7` | SHIFTER | Reversa |
 
+### H-shifter del SHIFTER device (verificado en F7 Norberto, 2026-05-06)
+
+| Posición física | Path Unity | Marcha |
+|---|---|---|
+| Trigger del palo | `shifter:trigger` | 1ª |
+| 2ª pos | `shifter:button2` | 2ª |
+| 3ª pos | `shifter:button3` | 3ª |
+| 4ª pos | `shifter:button4` | 4ª |
+| 5ª pos | `shifter:button5` | 5ª |
+| 6ª pos | `shifter:button6` | 6ª |
+| R | `shifter:button7` | -1 |
+
+**Nota crítica:** Unity nombra el control de la 1ª como `trigger` (no `button1`)
+porque el HID descriptor del HORI marca ese botón con un usage especial. Si se
+intenta `shifter:button1` el control no resuelve y la 1ª no funciona.
+
 ### Steering
 
 Pendiente de verificar el eje exacto. Pantalla 2 lo descubre dinamicamente.
@@ -81,12 +97,69 @@ Pendiente de verificar el eje exacto. Pantalla 2 lo descubre dinamicamente.
 | Rotacion | 900° | 1800° |
 | Botones | 19 | ~69 |
 
+## Modo manual (HORI + Manual + clutch, 2026-05-06)
+
+Al detectar HORI en `UIInputNew.AttachToWheelDevice()`, el bloque escribe los
+defaults del H-shifter de forma idempotente (`if (!HasKey)`) para que las
+reasignaciones F8 sobrevivan re-attaches:
+
+- `Bind_gear1 = "shifter:trigger"` (1ª)
+- `Bind_gear2..6 = "shifter:button2..6"` (2ª..6ª)
+- `Bind_reverse = "shifter:button7"` (R, ya cubre tanto automático como manual)
+
+El **clutch** NO se hardcodea: el HID descriptor del HORI alias `slider`/`slider1`/`rz`
+arbitrariamente entre brake y clutch (ver `HORI_THROTTLE_BUG_RESOLUTION.md:170-171`).
+Por eso `MenuScreenManager.PrepareWheelScreen()` agrega una **Phase 6 (CLUTCH)**
+condicional que corre solo si:
+- `TransmisionManual == 1`, **y**
+- `IsHORITruck(dev) == true`, **y**
+- No hay calibración válida del clutch persistida.
+
+La fase reusa la barra brake (sin nueva UI) y prompt "Pisa el EMBRAGUE a fondo".
+Excluye los axes ya elegidos para gas y brake — el restante (slider/slider1/rz)
+queda como `G923_ClutchAxis` con rest/press calibrados.
+
+### Detección de "rechino" en manual
+
+Mismo flujo que G923 PS: `UIInputNew` compara `_currentGear` contra
+`_lastNonNeutralGear`; si `clutchInput < 0.5` al cambiar, incrementa
+`_pendingGearShiftWithoutClutchCount`. `ViolationDetector` consume el contador
+y penaliza (−5 pts, audio `GearGrindingFeedback.PlayGrind()`) cuando
+`HasPhysicalClutch() == true`. Para HORI manual, `_clutchCtrl` queda no-null
+después de Phase 6 → `HasPhysicalClutch() == true`.
+
+### Cambio de hardware sin recalibrar
+
+Caso HORI→G923: los `Bind_gear*` con paths `shifter:*` no resuelven en G923.
+- `ReCacheGearControls()` filtra paths inválidos y, si `ctrls.Count == 0`,
+  cae al fallback legacy 13-19 → H-shifter G923 funciona.
+- `SanityCheckThenLoad` detecta paths `shifter:*` huérfanos (sin shifter
+  device) y los limpia de `Bind_gear*`/`Bind_reverse` → defaults del nuevo
+  hardware se reescriben en el siguiente attach.
+
 ## Pendiente
 
-- Verificar cual pedal fisico corresponde a cual eje (rz/slider/slider1)
-- Verificar eje del steering en Unity
-- Mapear marchas del H-shifter (buttons en SHIFTER device)
-- Verificar funcionamiento del force feedback
+- Verificar cual pedal fisico corresponde a cual eje (rz/slider/slider1) en F7
+- Verificar funcionamiento del force feedback (HORI no tiene FFB —
+  `LogitechFFB.cs` continúa siendo no-op)
+
+## Deuda técnica
+
+- **Alias del clutch en Phase 6 Discovery**: el HID parser de Unity alias
+  `slider`/`slider1`/`rz` arbitrariamente entre brake y clutch en el HORI
+  HPC-044U (lockstep parcial documentado en `HORI_THROTTLE_BUG_RESOLUTION.md:170-171`).
+  La exclusión por índice en `SamplePedalCandidates(gasIdx, brakeIdx, ...)`
+  evita reusar exactamente el mismo candidato pero NO previene que un
+  segundo alias del mismo byte físico gane la fase 6. **Síntomas observables**
+  si pasa: la barra del clutch avanza al pisar freno; en gameplay el clutch
+  se desacopla cuando el operador frena. **Mitigaciones futuras** (out of
+  scope inicial):
+  1. Verificación en dos pasos: detectar candidato al pisar clutch, soltar,
+     repisar y validar que el mismo eje vuelve a moverse fuerte mientras
+     los demás se quedan cerca del baseline.
+  2. Si Discovery falla en producción, agregar un sentinel
+     `HORI_RAW_CLUTCH_PATH` con lectura raw del byte HID análogo al throttle
+     (extender `HoriThrottleReader.cs`).
 
 ## Sources
 - [HORI USA Product Page](https://stores.horiusa.com/HPC-044U)


### PR DESCRIPTION
## Summary

- **Modo manual con H-shifter para HORI Truck (HPC-044U)** funcional. Mapping verificado en F7 por Norberto: 1ª=`shifter:trigger`, 2ª-6ª=`shifter:button2..6`, R=`shifter:button7`.
- **Phase 6 CLUTCH Discovery** condicional (Manual + HORI sin clutch axis previo) — descubre dinámicamente cuál de `slider`/`slider1`/`rz` es el pedal de clutch (no se hardcodea: Unity alias arbitrariamente entre brake y clutch, ver `HORI_THROTTLE_BUG_RESOLUTION.md`).
- **Bootstrap idempotente** del HORI: defaults en `AttachToWheelDevice` solo si `!HasKey`, así las reasignaciones F8 sobreviven re-attaches. El throttle bypass (`HORI_RAW_GAS_PATH`) sigue incondicional.
- **Hardening cross-hardware**: `ReCacheGearControls` cae al legacy 13-19 si todos los `Bind_gear*` son huérfanos (HORI→G923 sin recalibrar). `ClearWheelCalibration` y `SanityCheckThenLoad` extendidos para limpiar binds `shifter:*` huérfanos.
- **Fix bug HIGH** (codex review): el sanity check invalidaba toda calibración HORI cuando `gasPath == HORI_RAW_GAS_PATH` porque `TryGetChildControl(sentinel)` siempre devuelve null. Ahora se trata como caso especial.

Incluye también `f4fd3bc1` (subir maxSpeed 6ta de 160→180 km/h) que ya estaba en la branch.

Detección de "rechino" funciona igual que G923 PS — `HasPhysicalClutch()` queda true tras Phase 6 → `ViolationDetector` penaliza −5 pts.

## Test plan

- [ ] Build con `package-unity-build` y deploy a PC con HORI físico (Aramis SIM-008)
- [ ] Pantalla 1: seleccionar Manual → en F7 in-game `PlayerPrefs["TransmisionManual"]==1`
- [ ] Pantalla 2: si HORI primera calibración con Manual → completar Phase 6 (prompt "Pisa el EMBRAGUE a fondo"); persiste `G923_ClutchAxis`
- [ ] F7 in-game: mover palanca H → `_currentGear` cambia 0/1/2/3/4/5/6/-1; pisar clutch → `clutchInput` 0→1
- [ ] Escena `CamionDCarga`: 1ª→2ª SIN clutch dispara "−5 ¡CAMBIO SIN CLUTCH!"; CON clutch silencio
- [ ] Reversa con vel >5 km/h → "−20 ¡CAMBIO PELIGROSO!"
- [ ] Regresión G923: desconectar HORI, conectar G923 → fallback legacy 13-19, H-shifter sigue funcionando
- [ ] Idempotencia: F8 reasignar gear3 con HORI → reiniciar app → reasignación persiste

## Deuda técnica

- Alias del clutch en Discovery: si `slider`/`slider1`/`rz` están en lockstep parcial muy fuerte, Phase 6 podría capturar el axis del brake. Mitigaciones futuras documentadas en `PLAN_HORI_TRUCK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)