### PR TITLE
fix(manual): bypass del clutch solo para G923 Xbox detectado

### DIFF
--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -1720,21 +1720,34 @@ namespace Gley.UrbanSystem
                 }
 
                 // Aplicar el cambio de gear según el estado del clutch:
-                //  - clutch >= 0.5      → completar engage (cambio físico real)
+                //  - clutch >= 0.65     → completar engage (cambio físico real)
                 //  - desiredGear == 0   → permitir poner Neutral sin clutch
                 //                         (no requiere desacople mecánico)
                 //  - _currentGear == 0  → salir de Neutral SÍ requiere clutch
                 //                         (engage de marcha)
-                //  - sin clutch físico  → modo didáctico (G923 Xbox / Adv sin
-                //                         pedal). Aplicar siempre.
+                //  - G923 Xbox detectado → modo didáctico (no tiene pedal de
+                //                         clutch físico, no podemos exigirlo).
+                //                         IMPORTANTE: NO bypasseamos cuando
+                //                         _clutchCtrl es null por otras razones
+                //                         (HORI sin Phase 6 corrida, G923 PS
+                //                         sin EnsureG923PSDefaults). En esos
+                //                         casos clutchInput=0 forever y el
+                //                         bloqueo aplica — el conductor no
+                //                         puede avanzar hasta calibrar.
+                //                         Bug reportado por Norberto 2026-05-06:
+                //                         con _clutchCtrl=null el bypass dejaba
+                //                         pasar cambios sin clutch.
                 // Si nada aplica, el shifter "rechina" mecánicamente: el palo
                 // está en otra posición pero el motor sigue en la marcha vieja
                 // hasta que el conductor pise el clutch.
                 bool clutchPressed = clutchInput >= CLUTCH_ENGAGE_THRESHOLD;
                 bool toNeutral     = desiredGear == 0;
-                bool noPhysicalClutch = (_clutchCtrl == null);
+                bool isG923XboxNoClutch = _wheelDevice != null
+                    && IsLogitechG923Family(_wheelDevice)
+                    && (_wheelDevice.displayName ?? "")
+                        .IndexOf("Xbox", System.StringComparison.OrdinalIgnoreCase) >= 0;
                 bool sameGear      = desiredGear == _currentGear;
-                if (clutchPressed || toNeutral || noPhysicalClutch || sameGear)
+                if (clutchPressed || toNeutral || isG923XboxNoClutch || sameGear)
                 {
                     _currentGear = desiredGear;
                 }
@@ -1752,7 +1765,7 @@ namespace Gley.UrbanSystem
                         && desiredGear != _lastNonNeutralAttempt
                         && _lastNonNeutralAttempt != 0
                         && !clutchPressed
-                        && !noPhysicalClutch)
+                        && !isG923XboxNoClutch)
                     {
                         _pendingGearShiftWithoutClutchCount++;
                     }


### PR DESCRIPTION
## Summary

Bug reportado por Norberto en 1.5.1: a pesar del fix anterior (PR #152), las marchas seguían entrando sin pisar clutch.

**Causa**: la condición `noPhysicalClutch = (_clutchCtrl == null)` bypasseaba el bloqueo cuando el clutch axis no estaba calibrado por **cualquier** razón (HORI sin Phase 6 corrida, G923 PS sin defaults aplicados, prefs huérfanos). El "modo didáctico" se activaba mucho más allá del único caso real (G923 Xbox sin pedal).

**Fix**: detección explícita de G923 Xbox por displayName. Solo ese hardware bypassea el bloqueo:

```csharp
bool isG923XboxNoClutch = _wheelDevice != null
    && IsLogitechG923Family(_wheelDevice)
    && (_wheelDevice.displayName ?? "")
        .IndexOf("Xbox", System.StringComparison.OrdinalIgnoreCase) >= 0;
if (clutchPressed || toNeutral || isG923XboxNoClutch || sameGear) ...
```

Mismo cambio en el edge-trigger del rechino (`!noPhysicalClutch` → `!isG923XboxNoClutch`).

## Trade-off

Si HORI llega a la escena con `_clutchCtrl=null` (Phase 6 falló, lockstep parcial impidió Discovery), el conductor queda **atascado en N**. Es feedback correctivo vs el bug actual donde Manual era cosmético.

Si Phase 6 falla en producción, es bug separado para investigar — no este PR.

## Test plan

- [ ] **G923 PS Manual**: cambio sin clutch → bloqueado, coche en marcha vieja, audio rechino
- [ ] **HORI Manual con Phase 6 calibrada**: igual que arriba
- [ ] **G923 Xbox Manual**: cambio sin clutch → permitido (modo didáctico, no hay pedal físico)
- [ ] **HORI Manual sin Phase 6 (regresión esperada)**: cambios bloqueados, coche en N hasta recalibrar — confirmar que F7 muestra `_clutchCtrl=null` y el operador puede ir a Pantalla 2 → Reasignar controles para forzar Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)