### PR TITLE
fix(manual): eliminar bypass por hardware + auto-fallback Manual→Auto si sin clutch

### DIFF
--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -86,6 +86,9 @@ namespace Gley.UrbanSystem
         // sigue acoplado al eje viejo → coche acelera con marcha nueva sin
         // desacople real (bug encontrado por Codex review 2026-05-06).
         private const float CLUTCH_ENGAGE_THRESHOLD = 0.65f;
+        // Throttle del log de "Gear shift BLOQUEADO" para no spamear cada
+        // frame mientras el palo está en una posición que no se completa.
+        private float _lastBlockedShiftLogTime = -10f;
 
         // Curva de respuesta del volante: f(x) = x / (a + (1-a)*x)  para x ∈ [0,1]
         //   f(0) = 0, f(1) = 1 siempre
@@ -1203,6 +1206,21 @@ namespace Gley.UrbanSystem
 
             // Volante apareció después de Initialize → respetar PlayerPrefs de transmisión
             _isAutomaticMode = PlayerPrefs.GetInt("TransmisionManual", 0) == 0;
+            // Si Manual está seleccionado pero no hay clutch axis cacheado
+            // (HORI sin Phase 6 corrida, G923 Xbox sin pedal de clutch
+            // expuesto, prefs huérfanos), degradar a Auto. Sin esto el
+            // conductor quedaría atascado en Neutral con el bloqueo de
+            // cambios sin clutch sin posibilidad de pisar nada para
+            // desbloquearlo. Evita el bug reportado por Norberto donde el
+            // bypass anterior dejaba pasar cambios sin clutch en este caso.
+            if (!_isAutomaticMode && _clutchCtrl == null)
+            {
+                Debug.LogWarning($"[UIInputNew] Manual solicitado pero _clutchCtrl=null "
+                    + $"(G923_ClutchAxis='{clutchPath}'). Degradando a Auto. "
+                    + $"Device: '{device.displayName}'. "
+                    + $"Para Manual, calibrar clutch via Pantalla 2 → Reasignar controles.");
+                _isAutomaticMode = true;
+            }
             if (_isAutomaticMode && _currentGear == 0) _currentGear = 1;
 
             // Cargar calibración de pedales (rest+press) hecha en el menú.
@@ -1723,35 +1741,44 @@ namespace Gley.UrbanSystem
                 //  - clutch >= 0.65     → completar engage (cambio físico real)
                 //  - desiredGear == 0   → permitir poner Neutral sin clutch
                 //                         (no requiere desacople mecánico)
-                //  - _currentGear == 0  → salir de Neutral SÍ requiere clutch
-                //                         (engage de marcha)
-                //  - G923 Xbox detectado → modo didáctico (no tiene pedal de
-                //                         clutch físico, no podemos exigirlo).
-                //                         IMPORTANTE: NO bypasseamos cuando
-                //                         _clutchCtrl es null por otras razones
-                //                         (HORI sin Phase 6 corrida, G923 PS
-                //                         sin EnsureG923PSDefaults). En esos
-                //                         casos clutchInput=0 forever y el
-                //                         bloqueo aplica — el conductor no
-                //                         puede avanzar hasta calibrar.
-                //                         Bug reportado por Norberto 2026-05-06:
-                //                         con _clutchCtrl=null el bypass dejaba
-                //                         pasar cambios sin clutch.
+                //  - sameGear           → idempotente, sin cambio real
+                // SIN BYPASS por hardware: si Manual está activo, todos los
+                // hardware (G923 PS, G923 Xbox, HORI) requieren clutch ≥ 0.65.
+                // Para hardware sin pedal viable (Xbox sin clutch axis,
+                // HORI sin Phase 6), AttachToWheelDevice degrada Manual→Auto
+                // arriba (línea ~1207). Si llegamos aquí en Manual, _clutchCtrl
+                // != null por garantía.
                 // Si nada aplica, el shifter "rechina" mecánicamente: el palo
                 // está en otra posición pero el motor sigue en la marcha vieja
                 // hasta que el conductor pise el clutch.
                 bool clutchPressed = clutchInput >= CLUTCH_ENGAGE_THRESHOLD;
                 bool toNeutral     = desiredGear == 0;
-                bool isG923XboxNoClutch = _wheelDevice != null
-                    && IsLogitechG923Family(_wheelDevice)
-                    && (_wheelDevice.displayName ?? "")
-                        .IndexOf("Xbox", System.StringComparison.OrdinalIgnoreCase) >= 0;
                 bool sameGear      = desiredGear == _currentGear;
-                if (clutchPressed || toNeutral || isG923XboxNoClutch || sameGear)
+                if (clutchPressed || toNeutral || sameGear)
                 {
+                    int prevGear = _currentGear;
                     _currentGear = desiredGear;
+                    if (prevGear != _currentGear)
+                    {
+                        Debug.Log($"[UIInputNew] Gear shift OK: {prevGear}→{_currentGear}"
+                            + $" (clutchInput={clutchInput:F2} threshold={CLUTCH_ENGAGE_THRESHOLD:F2}"
+                            + $" toNeutral={toNeutral} sameGear={sameGear})");
+                    }
                 }
-                // else: bloqueado, _currentGear se mantiene.
+                else
+                {
+                    // Bloqueado: log periódico (cada 1.5s) para diagnóstico
+                    // remoto. Sin throttle, cada frame que el palo está en una
+                    // posición no-engaged spamearía decenas de líneas/seg.
+                    if (Time.realtimeSinceStartup - _lastBlockedShiftLogTime > 1.5f)
+                    {
+                        Debug.LogWarning($"[UIInputNew] Gear shift BLOQUEADO: pidió {desiredGear}"
+                            + $" pero queda en {_currentGear}"
+                            + $" (clutchInput={clutchInput:F2} threshold={CLUTCH_ENGAGE_THRESHOLD:F2}"
+                            + $" _clutchCtrl={(_clutchCtrl != null)})");
+                        _lastBlockedShiftLogTime = Time.realtimeSinceStartup;
+                    }
+                }
 
                 // Edge-trigger del rechino: cuenta UNA VEZ por intento real
                 // de cambio. Compara desiredGear contra _lastNonNeutralAttempt
@@ -1764,8 +1791,7 @@ namespace Gley.UrbanSystem
                     if (desiredGear != 0
                         && desiredGear != _lastNonNeutralAttempt
                         && _lastNonNeutralAttempt != 0
-                        && !clutchPressed
-                        && !isG923XboxNoClutch)
+                        && !clutchPressed)
                     {
                         _pendingGearShiftWithoutClutchCount++;
                     }

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.5.3
+  bundleVersion: 1.5.4
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
## Summary

Bug reportado: en 1.5.3 las marchas seguían entrando sin clutch en **G923 (Logitech)**, aunque HORI quedó OK con el fix anterior.

**Causa**: el bypass `isG923XboxNoClutch` que mantenía Xbox en "modo didáctico" dejaba pasar los cambios sin clutch.

**Fix definitivo (sin bypass por hardware):**

1. **Eliminar todo bypass del bloqueo**: la única forma de cambiar marcha en Manual es `clutchInput >= 0.65` (o Neutral, o sameGear).

2. **Auto-fallback Manual→Auto si `_clutchCtrl=null`** en `AttachToWheelDevice`: si Manual está pedido pero no hay clutch axis viable (HORI sin Phase 6, G923 Xbox sin clutch expuesto, prefs huérfanos), degradar a Auto + log warning. Evita que el conductor quede atascado.

3. **Logging detallado del cambio de gear**:
   - `Gear shift OK: 1→2 (clutchInput=0.78 ...)` cuando se permite.
   - `Gear shift BLOQUEADO: pidió 2 pero queda en 1 (clutchInput=0.30 ...)` throttled a 1.5s.

## Estado consolidado por hardware

| Hardware | Manual + sin clutch |
|---|---|
| G923 PS | Bloqueado (`stick/y` calibrado) |
| HORI con Phase 6 OK | Bloqueado (axis descubierto) |
| HORI sin Phase 6 | Auto-fallback (no atascado) |
| G923 Xbox | Auto-fallback (no tiene clutch viable) |

## Bump

`bundleVersion: 1.5.3 → 1.5.4` para que OTA distribuya.

## Test plan

- [ ] **G923 PS** Manual: cambio sin clutch → BLOQUEADO. Pisar clutch → cambio se completa.
- [ ] **HORI** Manual con Phase 6 calibrada: igual que arriba.
- [ ] **G923 Xbox** Manual: log warning en boot, escena arranca en Auto.
- [ ] Logs S3 muestran `Gear shift OK` o `Gear shift BLOQUEADO` con clutchInput real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)