### PR TITLE
fix(manual): bloquear Pantalla 2 con modal cuando Manual no es viable en hardware

### DIFF
--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -185,6 +185,15 @@ public class MenuScreenManager : MonoBehaviour
     // prueba..."). Se cancela si el usuario aprieta "Reasignar controles" o
     // si la pantalla se reabre durante el splash.
     private Coroutine sanityCheckCo;
+
+    // Pantalla 2: modal de "Manual no viable en este hardware". Cuando el
+    // device + calibración no soportan Manual (G923 Xbox sin clutch físico,
+    // HORI sin Phase 6 corrida), bloqueamos avance y le pedimos al usuario
+    // decidir entre continuar en Auto o volver a Pantalla 1. Re-purposamos
+    // skipButton/reassignButton — ver OnSkipWheel/OnReassignControls que
+    // dispatchean según _manualBlockedModalActive.
+    private bool _manualBlockedModalActive = false;
+    private UIInputNew.ManualBlockReason _manualBlockedReason = UIInputNew.ManualBlockReason.None;
     private const float WHEEL_THRESHOLD = 0.9f;
     private const float REVERSE_AXIS_DETECT_DELTA = 0.5f; // delta vs baseline para H-shifter en eje
     // Llave de PlayerPrefs con la huella (product|manufacturer|serial) del
@@ -1910,6 +1919,20 @@ public class MenuScreenManager : MonoBehaviour
         // ── 1) Detectar dispositivo y comparar huella con la calibración guardada ──
         InputDevice dev = TryAttachToDevice();
 
+        // ── 1.5) Bloquear avance si Manual no es viable en este hardware ──
+        // Antes de los fast-paths (moto/G923), validar que la combinación de
+        // device + TransmisionManual tiene clutch viable. Si no, mostrar modal
+        // explícito en vez de degradar silenciosamente a Auto en
+        // UIInputNew.AttachToWheelDevice (red de seguridad). Bug histórico:
+        // G923 Xbox + Manual entraba en Auto sin avisar al examinador, que
+        // luego "metía cambios sin clutch" porque realmente no estaba en manual.
+        var manualBlockReason = UIInputNew.GetManualBlockReason(dev);
+        if (manualBlockReason != UIInputNew.ManualBlockReason.None)
+        {
+            ShowManualBlockedDialog(manualBlockReason, dev);
+            return;
+        }
+
         // FAST-PATH: Moto Simulator (ESP32-S3 USB HID custom). Las 5 fases del
         // Discovery wheel-style no aplican a la moto: lean/handlebar son ejes
         // distintos, brake/clutch son botones (no ejes con rest/press), y la
@@ -2508,6 +2531,14 @@ public class MenuScreenManager : MonoBehaviour
 
     void OnSkipWheel()
     {
+        // Cuando el modal "Manual no viable" está activo, skipButton actúa como
+        // "Continuar en Automático" (ver ShowManualBlockedDialog). Dispatch
+        // antes que la lógica normal de skip.
+        if (_manualBlockedModalActive)
+        {
+            OnManualBlockedContinueAuto();
+            return;
+        }
         skipButton.interactable = false;
         wheelPrompt.text = "Cargando prueba...";
         var txt = skipButton.GetComponentInChildren<TextMeshProUGUI>();
@@ -2923,6 +2954,13 @@ public class MenuScreenManager : MonoBehaviour
 
     void OnReassignControls()
     {
+        // Cuando el modal "Manual no viable" está activo, reassignButton actúa
+        // como "Volver a transmisión" (ver ShowManualBlockedDialog).
+        if (_manualBlockedModalActive)
+        {
+            OnManualBlockedCancelToOptions();
+            return;
+        }
         Debug.Log("[MenuScreenManager] Reasignar controles solicitado por usuario");
         if (sanityCheckCo != null) { StopCoroutine(sanityCheckCo); sanityCheckCo = null; }
         ClearWheelCalibration();
@@ -2932,6 +2970,126 @@ public class MenuScreenManager : MonoBehaviour
         if (steerAction != null) { steerAction.Disable(); steerAction.Dispose(); steerAction = null; }
         _steerExcludedPedalIdx = -1;
         PrepareWheelScreen();
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Modal "Manual no viable en este hardware"
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // Pantalla 2 lo activa antes de cualquier fast-path cuando el examinador
+    // eligió Manual pero el device actual no expone clutch viable (G923 Xbox
+    // sin pedal físico, HORI sin Phase 6 corrida). Re-purposa skipButton +
+    // reassignButton (los handlers ya existentes dispatchean al modal cuando
+    // _manualBlockedModalActive==true). Sin este modal, el examen entraría
+    // en Auto degradado silenciosamente y el examinador "metería cambios sin
+    // clutch" sin saber que no estaba en manual.
+
+    void ShowManualBlockedDialog(UIInputNew.ManualBlockReason reason, InputDevice dev)
+    {
+        _manualBlockedModalActive = true;
+        _manualBlockedReason = reason;
+
+        string deviceName = dev != null ? (dev.displayName ?? "desconocido") : "ninguno";
+        Debug.LogWarning($"[MenuScreenManager] [MANUAL_BLOCKED] reason={reason} device='{deviceName}' — bloqueando Pantalla 2 con modal");
+
+        // Cancelar splash en curso si lo había.
+        if (sanityCheckCo != null) { StopCoroutine(sanityCheckCo); sanityCheckCo = null; }
+
+        // Cortar el loop de Update() que animaría las barras de calibración
+        // mientras el modal está visible. Marcando todas las fases como "done"
+        // hace que la guard `if (rightDone && ... ) return;` short-circuitee.
+        rightDone = leftDone = throttleDone = brakeDone = reverseDone = clutchDone = true;
+
+        // Mensaje específico según el motivo. Le decimos al usuario QUÉ hardware
+        // tenemos y QUÉ falta — sin eso el operador no sabe si es bug o config.
+        string msg;
+        switch (reason)
+        {
+            case UIInputNew.ManualBlockReason.NoPhysicalClutch_G923Xbox:
+                msg = "Tu volante <b>Logitech G923 (variante Xbox)</b> no tiene pedal físico de clutch.\n\n" +
+                      "El examen Manual requiere clutch para evaluar correctamente los cambios.\n\n" +
+                      "Puedes <b>continuar en Automático</b> (la prueba se evaluará sin clutch) o " +
+                      "<b>volver atrás</b> para elegir transmisión Automática explícitamente.";
+                break;
+            case UIInputNew.ManualBlockReason.NoPhysicalClutch_HORINotCalibrated:
+                msg = "El volante <b>HORI Truck</b> no tiene el clutch calibrado.\n\n" +
+                      "Para correr en Manual hay que asignar el pedal de clutch via " +
+                      "<b>Reasignar controles</b> (en la pantalla normal de Pantalla 2).\n\n" +
+                      "¿Continuar en Automático o volver a la pantalla de transmisión?";
+                break;
+            case UIInputNew.ManualBlockReason.UnknownDeviceCannotProveClutch:
+                msg = $"El volante conectado (<b>{deviceName}</b>) no se reconoce como compatible con Manual.\n\n" +
+                      "El examen Manual requiere clutch físico calibrado.\n\n" +
+                      "Puedes <b>continuar en Automático</b> o <b>volver atrás</b> para elegir Automático.";
+                break;
+            default:
+                msg = "Manual no es viable en este hardware. Continúa en Automático o vuelve atrás.";
+                break;
+        }
+        if (wheelPrompt != null) wheelPrompt.text = msg;
+
+        // Re-purposar botones: skipButton="Continuar en Automático" (primary),
+        // reassignButton="Volver a transmisión" (secondary). Ambos visibles e
+        // interactuables.
+        if (skipButton != null)
+        {
+            var t = skipButton.GetComponentInChildren<TextMeshProUGUI>();
+            if (t != null) t.text = "Continuar en Automático";
+            skipButton.interactable = true;
+            skipButton.gameObject.SetActive(true);
+        }
+        if (reassignButton != null)
+        {
+            var t = reassignButton.GetComponentInChildren<TextMeshProUGUI>();
+            if (t != null) t.text = "Volver a transmisión";
+            reassignButton.interactable = true;
+            reassignButton.gameObject.SetActive(true);
+        }
+    }
+
+    void OnManualBlockedContinueAuto()
+    {
+        Debug.Log($"[MenuScreenManager] [MANUAL_BLOCKED] usuario eligió 'Continuar en Automático' (reason={_manualBlockedReason})");
+        // Persistir Auto. UIInputNew.AttachToWheelDevice lee TransmisionManual
+        // en cada call, así que el siguiente flow de PrepareWheelScreen ya
+        // verá Auto y GetManualBlockReason retornará None.
+        PlayerPrefs.SetInt("TransmisionManual", 0);
+        PlayerPrefs.Save();
+        // También actualizar el estado del selector en memoria para que
+        // Pantalla 1 lo refleje si el usuario regresa.
+        selectedTransmisionIndex = 0;
+
+        ClearManualBlockedModalState();
+        // Re-correr la pantalla con TransmisionManual=0 — esta vez los
+        // fast-paths (moto/G923) corren normalmente.
+        PrepareWheelScreen();
+    }
+
+    void OnManualBlockedCancelToOptions()
+    {
+        Debug.Log($"[MenuScreenManager] [MANUAL_BLOCKED] usuario eligió 'Volver a transmisión' (reason={_manualBlockedReason})");
+        ClearManualBlockedModalState();
+        // SCREEN_OPTIONS es la pantalla con el selector Manual/Auto (Pantalla 1).
+        GoToScreen(SCREEN_OPTIONS);
+    }
+
+    void ClearManualBlockedModalState()
+    {
+        _manualBlockedModalActive = false;
+        _manualBlockedReason = UIInputNew.ManualBlockReason.None;
+        // Restaurar texto de los botones. PrepareWheelScreen va a re-asignar
+        // visibilidad según el flujo (Verified/Partial/Discovery), pero los
+        // strings se quedan pegados — restaurarlos explícitamente.
+        if (skipButton != null)
+        {
+            var t = skipButton.GetComponentInChildren<TextMeshProUGUI>();
+            if (t != null) t.text = "Iniciar sin volante";
+        }
+        if (reassignButton != null)
+        {
+            var t = reassignButton.GetComponentInChildren<TextMeshProUGUI>();
+            if (t != null) t.text = "Reasignar controles";
+        }
     }
 
     // Splash de "Preparando prueba..." en estado Verified. Verifica que los

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -8,6 +8,20 @@ namespace Gley.UrbanSystem
 {
     public class UIInputNew : MonoBehaviour, IUIInput
     {
+        // Razón por la que el modo Manual no es viable en el device actual.
+        // Pantalla 2 consulta GetManualBlockReason() ANTES del fast-path G923
+        // y bloquea el avance con un modal si el resultado es != None — ver
+        // MenuScreenManager.PrepareWheelScreen. La red de seguridad de
+        // AttachToWheelDevice (Debug.LogError + degrade Manual→Auto) usa
+        // el mismo enum para reportar.
+        public enum ManualBlockReason
+        {
+            None,
+            NoPhysicalClutch_G923Xbox,
+            NoPhysicalClutch_HORINotCalibrated,
+            UnknownDeviceCannotProveClutch
+        }
+
 #if (UNITY_ANDROID || UNITY_IOS) && !UNITY_EDITOR
         public delegate void ButtonDown(string button);
         public static event ButtonDown onButtonDown;
@@ -848,6 +862,57 @@ namespace Gley.UrbanSystem
             return false;
         }
 
+        // True si el G923 es la variante Xbox (sin pedal físico de clutch).
+        // EnsureG923PSDefaults usa solo displayName.Contains("Xbox"); este
+        // helper también revisa description.product como red de robustez —
+        // Unity Input System en Windows a veces popula uno y no el otro.
+        // Retorna false si el device NO es G923 family.
+        public static bool IsG923XboxVariant(InputDevice d)
+        {
+            if (d == null || !IsLogitechG923Family(d)) return false;
+            string name = d.displayName ?? string.Empty;
+            string product = d.description.product ?? string.Empty;
+            return name.IndexOf("Xbox", System.StringComparison.OrdinalIgnoreCase) >= 0
+                || product.IndexOf("Xbox", System.StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        // Decide si el dispositivo + estado de calibración permite correr Manual.
+        // Solo retorna != None cuando TransmisionManual==1 (sin esa pref activa
+        // no hay nada que bloquear). Pantalla 2 consume el resultado para
+        // mostrar un modal explícito antes de cargar la escena, en vez de
+        // confiar solo en el degrade silencioso de AttachToWheelDevice.
+        public static ManualBlockReason GetManualBlockReason(InputDevice d)
+        {
+            if (PlayerPrefs.GetInt("TransmisionManual", 0) != 1)
+                return ManualBlockReason.None;
+            if (d == null)
+                return ManualBlockReason.UnknownDeviceCannotProveClutch;
+
+            if (IsLogitechG923Family(d))
+            {
+                if (IsG923XboxVariant(d))
+                    return ManualBlockReason.NoPhysicalClutch_G923Xbox;
+                // PS variant: EnsureG923PSDefaults hardcodea clutch=stick/y → viable
+                return ManualBlockReason.None;
+            }
+
+            if (IsHORITruck(d))
+            {
+                string clutchPath = PlayerPrefs.GetString(PREF_G923_CLUTCH_AXIS, "");
+                if (string.IsNullOrEmpty(clutchPath))
+                    return ManualBlockReason.NoPhysicalClutch_HORINotCalibrated;
+                return ManualBlockReason.None;
+            }
+
+            // Moto sim: Pantalla 2 ya tiene fast-path propio (no llega aquí en
+            // flujo normal). Cualquier otro device desconocido en Manual: no
+            // podemos probar que tiene clutch — bloquear es lo conservador.
+            if (IsMotoSimulator(d))
+                return ManualBlockReason.None;
+
+            return ManualBlockReason.UnknownDeviceCannotProveClutch;
+        }
+
         public static bool IsKnownWheelCandidate(InputDevice d)
         {
             if (IsLogitechG923Family(d)) return true;
@@ -1215,9 +1280,16 @@ namespace Gley.UrbanSystem
             // bypass anterior dejaba pasar cambios sin clutch en este caso.
             if (!_isAutomaticMode && _clutchCtrl == null)
             {
-                Debug.LogWarning($"[UIInputNew] Manual solicitado pero _clutchCtrl=null "
-                    + $"(G923_ClutchAxis='{clutchPath}'). Degradando a Auto. "
-                    + $"Device: '{device.displayName}'. "
+                // Red de seguridad: Pantalla 2 (MenuScreenManager.PrepareWheelScreen)
+                // ya debió haber bloqueado esta combinación con un modal usando
+                // GetManualBlockReason. Si llegamos aquí significa que el flujo
+                // saltó esa validación — es un bug que LogUploader debe capturar
+                // a S3 para diagnóstico remoto. LogError (no Warning) para que
+                // destaque y para que no se confunda con el "BLOQUEADO" normal.
+                var reason = GetManualBlockReason(device);
+                Debug.LogError($"[UIInputNew] [MANUAL_DEGRADED_TO_AUTO] reason={reason} "
+                    + $"device='{device.displayName}' clutchPath='{clutchPath}' "
+                    + $"— Pantalla 2 NO bloqueó esta combinación. Degradando a Auto. "
                     + $"Para Manual, calibrar clutch via Pantalla 2 → Reasignar controles.");
                 _isAutomaticMode = true;
             }


### PR DESCRIPTION
## Resumen

Repro: Logitech G923 **variante Xbox** + selector Manual en Pantalla 1 → entraba al examen y los cambios del H-shifter pasaban sin pisar clutch. Reportado en kiosko de la gobernadora.

**Causa raíz** (confirmada por Codex review): el G923 Xbox no expone eje físico de clutch — `stick/y` lo usa el acelerador. `UIInputNew.cs:1216` ya degradaba Manual→Auto cuando `_clutchCtrl == null`, pero con un `LogWarning` invisible al usuario. El examinador creía estar en manual pero realmente estaba en Auto, por eso "podía meter cambios sin clutch". **Bug de contrato de producto, no de bypass de validación.**

**Fix**: bloquear Pantalla 2 con modal explícito ANTES de los fast-paths cuando la combinación device + TransmisionManual no soporta clutch viable.

## Cambios

### `UIInputNew.cs`
- Nuevo `enum ManualBlockReason { None, NoPhysicalClutch_G923Xbox, NoPhysicalClutch_HORINotCalibrated, UnknownDeviceCannotProveClutch }`.
- Nuevo `static GetManualBlockReason(InputDevice)` que filtra por `TransmisionManual==1` y reporta el motivo.
- Nuevo `static IsG923XboxVariant(InputDevice)` con detección robusta vía `displayName` Y `description.product` (gotcha de Codex — `EnsureG923PSDefaults` solo revisa `displayName`).
- Línea 1216: red de seguridad mantenida pero hardenada: `LogWarning` → `LogError` con tag `[MANUAL_DEGRADED_TO_AUTO]` capturado automáticamente por `LogUploader.cs` → S3 para diagnóstico remoto si Pantalla 2 falla en bloquear.

### `MenuScreenManager.cs`
- Check temprano en `PrepareWheelScreen` antes de los fast-paths (moto/G923/HORI Discovery).
- `ShowManualBlockedDialog` re-purposea `skipButton` ("Continuar en Automático") y `reassignButton` ("Volver a transmisión"). `OnSkipWheel`/`OnReassignControls` dispatchean según `_manualBlockedModalActive`. Sin UI nueva — consistente con el resto del menú.
- Mensajes específicos por motivo (G923 Xbox / HORI sin Phase 6 / device desconocido).
- Marca `*Done=true` para cortar el loop de calibración del `Update()` mientras el modal está visible.

## NO se hizo

- Mapear paddle/L2/R2 como "clutch digital" para salvar Manual en Xbox. La prueba está modelada alrededor de un pedal físico (penalizaciones por rechino, `HasPhysicalClutch`, métricas del examen). Inventar clutch digital cambia la naturaleza de la prueba — decisión de producto, ticket separado.

## Test plan

- [ ] **Repro original**: G923 Xbox + Manual → modal aparece, no avanza al examen.
- [ ] "Continuar en Automático" → persiste TransmisionManual=0, procede al fast-path G923 normal, examen carga en Auto.
- [ ] "Volver a transmisión" → vuelve a Pantalla 1 con selector visible.
- [ ] **Regresión G923 PS + Manual** (kiosko Aramis): Discovery completo (5 fases + Phase 6), entra SIN modal, en escena `clutchInput >= 0.65` sigue siendo necesario para cambio (logs `Gear shift OK`/`BLOQUEADO`), penalización de rechino activa.
- [ ] **Regresión G923 Xbox + Auto**: entra sin modal ni warnings.
- [ ] **Regresión HORI + Manual sin Phase 6**: muestra modal con mensaje específico distinto al de Xbox.
- [ ] **Regresión HORI + Manual con Phase 6 calibrada**: entra SIN modal, comportamiento manual igual que antes.
- [ ] **Regresión HORI + Auto**: entra sin modal.
- [ ] **Logs S3**: si por algún path la red de seguridad de `UIInputNew.cs:1216` dispara, debe haber `[MANUAL_DEGRADED_TO_AUTO]` capturado por LogUploader → S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)