### PR TITLE
fix(hori): v1.6.2 → v1.6.7 calibration + gear shifting hardening

### DIFF
--- a/2026MVP/AGENTS.md
+++ b/2026MVP/AGENTS.md
@@ -1,0 +1,52 @@
+# Tlax2026MVP
+
+Proyecto Unity del simulador de examen de manejo. Antes de editar, asumir que aquí conviven código propio y assets de terceros.
+
+## No tocar
+
+No modificar assets comprados salvo que el usuario lo pida explícitamente y el cambio esté bien justificado:
+
+- `Assets/Realistic Car Controller Pro/`
+- `Assets/Gley/`
+- `Assets/EasyRoads3D/`
+- `Assets/EasyRoads3Dv3/`
+- `Assets/Fantasy Skybox FREE/`
+
+## Stack y restricciones
+
+- Unity 6 `6000.3.5f2`
+- URP
+- Input System nuevo solamente
+- Build target Windows
+
+No introducir APIs del input legacy si el código actual usa Input System.
+
+## Áreas clave del código propio
+
+- `Assets/Custom/`: gameplay, UI, diagnósticos, kiosko, logging.
+- `Assets/Custom/Menu/`: flujo principal de verificación e inicio de examen.
+- `Assets/pruebasQR/`: QR y sesiones de kiosko.
+- `scripts/`: utilidades de build e instalación.
+
+## Operación de builds
+
+Hay dos flujos distintos heredados de Claude y conviene no mezclarlos:
+
+- Empaquetado LAN local: `../../.claude/skills/package-unity-build/SKILL.md`
+- Publicación al portal admin y deploy OTA: `../../.claude/skills/publish-unity-build/SKILL.md`
+
+Diferencia crítica:
+
+- El zip LAN lleva wrapper `Tlax2026MVP/` como raíz.
+- El zip para el portal admin va con archivos al root del zip.
+
+## Reglas prácticas
+
+- Si el usuario pide publicar una versión, verificar primero si Unity está abierto antes de batch build.
+- No matar Unity a la fuerza sin permiso explícito del usuario.
+- Si trabajas en OTA, heartbeat o update status, preservar la lógica de confirmación honesta de instalaciones.
+- Si tocas logging o diagnósticos, cuidar tanto `LogConsolePanel` como `LogUploader`; se usan para soporte en kioskos reales.
+
+## Referencia extendida
+
+Para arquitectura, overlays F7-F10, QR, NPCs, OTA y flujo del simulador, ver `Manejo/2026MVP/CLAUDE.md`.

--- a/2026MVP/Assets/Custom/HoriShifterReader.cs
+++ b/2026MVP/Assets/Custom/HoriShifterReader.cs
@@ -1,0 +1,494 @@
+// HoriShifterReader.cs — continuous raw HID reader for HORI Truck shifter lever.
+//
+// Replaces the pulse-based button7 heuristic (v1.5.8-v1.5.12 sticky latch) with
+// direct P/Invoke HID reading. Same pattern as HoriThrottleReader.cs.
+//
+// The HORI HPC-044U shifter reports gear positions as buttons (trigger=1st,
+// button2-6=2nd-6th, button7=R) through Unity Input System, but button7 only
+// fires as a 1-2 frame PULSE. This reader opens the raw HID handle and reads
+// the actual byte state, bypassing Unity's parser.
+//
+// On first connect, logs all byte changes to the console for discovery. Once
+// the gear byte is identified (either auto-detected or via PlayerPrefs config),
+// provides persistent gear position to UIInputNew.
+
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+#define HORI_USE_PINVOKE
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+#if HORI_USE_PINVOKE
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+#endif
+
+public class HoriShifterReader : MonoBehaviour
+{
+    static HoriShifterReader _instance;
+    public static HoriShifterReader Instance => _instance;
+
+    public int CurrentGear => _currentGear;
+    private volatile int _currentGear;
+
+    public bool IsLeverInR => _currentGear == -1;
+    public bool IsConnected => _connected;
+    private volatile bool _connected;
+
+#if HORI_USE_PINVOKE
+    private const int VID = 0x0F0D;
+
+    // Gear byte/bit mapping. Configured via PlayerPrefs after discovery.
+    // -1 = not yet calibrated (discovery mode active).
+    private int _gearByteIndex = -1;
+    private int _reverseBit = -1;   // bit index 0-7 within the gear byte
+    private int _gear1Bit = -1;
+    private int _gear2Bit = -1;
+    private int _gear3Bit = -1;
+    private int _gear4Bit = -1;
+    private int _gear5Bit = -1;
+    private int _gear6Bit = -1;
+    // Alternative: some shifters encode gear position as a single value
+    // in one byte (hat-switch style), not as individual button bits.
+    // Set to true if we discover that pattern.
+    private bool _useValueMode;
+    private int _valueByteIndex = -1;
+    private int _valueReverse = -1;
+    private int _valueGear1 = -1;
+    private int _valueGear2 = -1;
+    private int _valueGear3 = -1;
+    private int _valueGear4 = -1;
+    private int _valueGear5 = -1;
+    private int _valueGear6 = -1;
+    private int _valueNeutral = -1;
+
+    private bool _calibrated;
+    // Habilita el spam de "CHG b##:XX->YY" después de calibrate=True (default OFF
+    // en producción para no ahogar Player.log con miles de líneas por minuto).
+    // Activar desde shell: PlayerPrefs SetInt Diag_HoriHidProbe 1 (mismo patrón
+    // que Diag_HoriShifterProbe que gatea HoriShifterProbe.Bootstrap).
+    private bool _diagLogEnabled;
+    private SafeFileHandle _hidHandle;
+    private Thread _pollerThread;
+    private volatile bool _running;
+    private string _devicePath;
+    private float _retryTimer;
+
+    private const string PREF_PREFIX = "HoriShifter_";
+    private const string PREF_DIAG_LOG = "Diag_HoriHidProbe";
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Bootstrap()
+    {
+        if (_instance != null) return;
+        var go = new GameObject("[HoriShifterReader]");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<HoriShifterReader>();
+        Gley.UrbanSystem.UIInputNew.HoriShifterStateProvider = () =>
+            _instance != null && _instance._connected ? _instance.CurrentGear : int.MinValue;
+        Debug.Log("[HoriShifterReader] Bootstrapped — raw HID reader for HORI shifter lever position");
+    }
+
+    void Start()
+    {
+        _diagLogEnabled = PlayerPrefs.GetInt(PREF_DIAG_LOG, 0) == 1;
+        LoadCalibration();
+        if (!_calibrated)
+            ApplyHPC044UDefaults();
+        if (_diagLogEnabled)
+            Debug.Log("[HoriShifterReader] Diag_HoriHidProbe=1 — CHG spam habilitado para diagnóstico");
+        TryStartPoller();
+    }
+
+    // HPC-044U (PID 0x0186) verified mapping: b01 bits, persistent while in gear.
+    void ApplyHPC044UDefaults()
+    {
+        _useValueMode = false;
+        _gearByteIndex = 1;
+        _gear1Bit = 0;   // 0x01
+        _gear2Bit = 1;   // 0x02
+        _gear3Bit = 2;   // 0x04
+        _gear4Bit = 3;   // 0x08
+        _gear5Bit = 4;   // 0x10
+        _gear6Bit = 5;   // 0x20
+        _reverseBit = 6; // 0x40
+        _calibrated = true;
+        Debug.Log("[HoriShifterReader] Applied HPC-044U defaults: byte[1] bits 0-5=gears, 6=R");
+    }
+
+    void Update()
+    {
+        if (_pollerThread != null && _pollerThread.IsAlive) return;
+        _retryTimer += Time.unscaledDeltaTime;
+        if (_retryTimer >= 2f)
+        {
+            _retryTimer = 0f;
+            TryStartPoller();
+        }
+    }
+
+    void LoadCalibration()
+    {
+        string mode = PlayerPrefs.GetString(PREF_PREFIX + "Mode", "");
+        if (mode == "bits")
+        {
+            _gearByteIndex = PlayerPrefs.GetInt(PREF_PREFIX + "ByteIndex", -1);
+            _reverseBit = PlayerPrefs.GetInt(PREF_PREFIX + "ReverseBit", -1);
+            _gear1Bit = PlayerPrefs.GetInt(PREF_PREFIX + "Gear1Bit", -1);
+            _gear2Bit = PlayerPrefs.GetInt(PREF_PREFIX + "Gear2Bit", -1);
+            _gear3Bit = PlayerPrefs.GetInt(PREF_PREFIX + "Gear3Bit", -1);
+            _gear4Bit = PlayerPrefs.GetInt(PREF_PREFIX + "Gear4Bit", -1);
+            _gear5Bit = PlayerPrefs.GetInt(PREF_PREFIX + "Gear5Bit", -1);
+            _gear6Bit = PlayerPrefs.GetInt(PREF_PREFIX + "Gear6Bit", -1);
+            _calibrated = _gearByteIndex >= 0 && _reverseBit >= 0;
+            if (_calibrated)
+                Debug.Log($"[HoriShifterReader] Loaded bits calibration: byte[{_gearByteIndex}] R=bit{_reverseBit}");
+        }
+        else if (mode == "value")
+        {
+            _useValueMode = true;
+            _valueByteIndex = PlayerPrefs.GetInt(PREF_PREFIX + "ValueByteIndex", -1);
+            _valueNeutral = PlayerPrefs.GetInt(PREF_PREFIX + "ValueNeutral", -1);
+            _valueReverse = PlayerPrefs.GetInt(PREF_PREFIX + "ValueReverse", -1);
+            _valueGear1 = PlayerPrefs.GetInt(PREF_PREFIX + "ValueGear1", -1);
+            _valueGear2 = PlayerPrefs.GetInt(PREF_PREFIX + "ValueGear2", -1);
+            _valueGear3 = PlayerPrefs.GetInt(PREF_PREFIX + "ValueGear3", -1);
+            _valueGear4 = PlayerPrefs.GetInt(PREF_PREFIX + "ValueGear4", -1);
+            _valueGear5 = PlayerPrefs.GetInt(PREF_PREFIX + "ValueGear5", -1);
+            _valueGear6 = PlayerPrefs.GetInt(PREF_PREFIX + "ValueGear6", -1);
+            _calibrated = _valueByteIndex >= 0 && _valueReverse >= 0;
+            if (_calibrated)
+                Debug.Log($"[HoriShifterReader] Loaded value calibration: byte[{_valueByteIndex}] R={_valueReverse}");
+        }
+    }
+
+    /// <summary>Configure gear mapping in bits mode (each gear = one bit in a byte).
+    /// Call from console or discovery tool, then call SaveCalibration().</summary>
+    public void ConfigureBitsMode(int byteIndex, int rBit, int g1Bit, int g2Bit, int g3Bit, int g4Bit, int g5Bit, int g6Bit)
+    {
+        _useValueMode = false;
+        _gearByteIndex = byteIndex;
+        _reverseBit = rBit;
+        _gear1Bit = g1Bit;
+        _gear2Bit = g2Bit;
+        _gear3Bit = g3Bit;
+        _gear4Bit = g4Bit;
+        _gear5Bit = g5Bit;
+        _gear6Bit = g6Bit;
+        _calibrated = true;
+        SaveCalibration();
+        Debug.Log($"[HoriShifterReader] Configured bits mode: byte[{byteIndex}] R=bit{rBit} 1=bit{g1Bit} ... 6=bit{g6Bit}");
+    }
+
+    /// <summary>Configure gear mapping in value mode (single byte encodes gear as a number).</summary>
+    public void ConfigureValueMode(int byteIndex, int neutral, int reverse, int g1, int g2, int g3, int g4, int g5, int g6)
+    {
+        _useValueMode = true;
+        _valueByteIndex = byteIndex;
+        _valueNeutral = neutral;
+        _valueReverse = reverse;
+        _valueGear1 = g1;
+        _valueGear2 = g2;
+        _valueGear3 = g3;
+        _valueGear4 = g4;
+        _valueGear5 = g5;
+        _valueGear6 = g6;
+        _calibrated = true;
+        SaveCalibration();
+        Debug.Log($"[HoriShifterReader] Configured value mode: byte[{byteIndex}] N={neutral} R={reverse} 1={g1} ... 6={g6}");
+    }
+
+    void SaveCalibration()
+    {
+        if (_useValueMode)
+        {
+            PlayerPrefs.SetString(PREF_PREFIX + "Mode", "value");
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueByteIndex", _valueByteIndex);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueNeutral", _valueNeutral);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueReverse", _valueReverse);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueGear1", _valueGear1);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueGear2", _valueGear2);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueGear3", _valueGear3);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueGear4", _valueGear4);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueGear5", _valueGear5);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ValueGear6", _valueGear6);
+        }
+        else
+        {
+            PlayerPrefs.SetString(PREF_PREFIX + "Mode", "bits");
+            PlayerPrefs.SetInt(PREF_PREFIX + "ByteIndex", _gearByteIndex);
+            PlayerPrefs.SetInt(PREF_PREFIX + "ReverseBit", _reverseBit);
+            PlayerPrefs.SetInt(PREF_PREFIX + "Gear1Bit", _gear1Bit);
+            PlayerPrefs.SetInt(PREF_PREFIX + "Gear2Bit", _gear2Bit);
+            PlayerPrefs.SetInt(PREF_PREFIX + "Gear3Bit", _gear3Bit);
+            PlayerPrefs.SetInt(PREF_PREFIX + "Gear4Bit", _gear4Bit);
+            PlayerPrefs.SetInt(PREF_PREFIX + "Gear5Bit", _gear5Bit);
+            PlayerPrefs.SetInt(PREF_PREFIX + "Gear6Bit", _gear6Bit);
+        }
+        PlayerPrefs.Save();
+    }
+
+    void TryStartPoller()
+    {
+        try
+        {
+            string path = FindShifterPath();
+            if (string.IsNullOrEmpty(path)) return;
+            _devicePath = path;
+            _hidHandle = CreateFile(path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (_hidHandle.IsInvalid)
+            {
+                int err = Marshal.GetLastWin32Error();
+                Debug.LogWarning($"[HoriShifterReader] CreateFile failed path='{path}' err={err}");
+                _hidHandle.Dispose();
+                _hidHandle = null;
+                return;
+            }
+            _running = true;
+            _connected = true;
+            _pollerThread = new Thread(PollLoop) { IsBackground = true, Name = "HoriShifterPoller" };
+            _pollerThread.Start();
+            Debug.Log($"[HoriShifterReader] Started poller on {path} (calibrated={_calibrated})");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[HoriShifterReader] TryStartPoller exception: {ex.Message}");
+        }
+    }
+
+    void PollLoop()
+    {
+        byte[] buffer = new byte[64];
+        byte[] prev = new byte[64];
+        bool first = true;
+        var sb = new System.Text.StringBuilder(256);
+        long lastLogMs = 0;
+
+        while (_running)
+        {
+            try
+            {
+                bool ok = ReadFile(_hidHandle, buffer, (uint)buffer.Length, out uint bytesRead, IntPtr.Zero);
+                if (!ok)
+                {
+                    if (_running)
+                    {
+                        int err = Marshal.GetLastWin32Error();
+                        Debug.LogWarning($"[HoriShifterReader] ReadFile failed err={err}, stopping");
+                    }
+                    break;
+                }
+                if (bytesRead == 0) continue;
+
+                // --- Discovery logging: always log byte changes ---
+                long nowMs = Environment.TickCount;
+                if (first)
+                {
+                    sb.Length = 0;
+                    sb.Append($"[HoriShifterReader] INIT {bytesRead}B:");
+                    for (int i = 0; i < (int)bytesRead && i < 32; i++)
+                        sb.AppendFormat(" b{0:D2}={1:X2}", i, buffer[i]);
+                    Debug.Log(sb.ToString());
+                    Buffer.BlockCopy(buffer, 0, prev, 0, (int)bytesRead);
+                    first = false;
+                    continue;
+                }
+
+                bool anyChange = false;
+                for (int i = 0; i < (int)bytesRead && i < prev.Length; i++)
+                {
+                    if (buffer[i] != prev[i]) { anyChange = true; break; }
+                }
+
+                // Spam silenciado en producción cuando ya hay calibración activa.
+                // Durante discovery (!_calibrated) seguimos logueando para no
+                // perder el descubrimiento del byte de palanca. Diag_HoriHidProbe=1
+                // re-habilita el spam para troubleshooting remoto.
+                bool logChanges = !_calibrated || _diagLogEnabled;
+                if (logChanges && anyChange && (nowMs - lastLogMs) >= 100)
+                {
+                    sb.Length = 0;
+                    sb.Append("[HoriShifterReader] CHG");
+                    for (int i = 0; i < (int)bytesRead && i < prev.Length; i++)
+                    {
+                        if (buffer[i] != prev[i])
+                            sb.AppendFormat(" b{0:D2}:{1:X2}->{2:X2}", i, prev[i], buffer[i]);
+                    }
+                    Debug.Log(sb.ToString());
+                    lastLogMs = nowMs;
+                }
+                Buffer.BlockCopy(buffer, 0, prev, 0, (int)bytesRead);
+
+                // --- Derive current gear from raw bytes ---
+                if (_calibrated)
+                {
+                    if (_useValueMode)
+                    {
+                        if (_valueByteIndex >= 0 && _valueByteIndex < (int)bytesRead)
+                        {
+                            int val = buffer[_valueByteIndex];
+                            if (val == _valueReverse)     _currentGear = -1;
+                            else if (val == _valueGear1)  _currentGear = 1;
+                            else if (val == _valueGear2)  _currentGear = 2;
+                            else if (val == _valueGear3)  _currentGear = 3;
+                            else if (val == _valueGear4)  _currentGear = 4;
+                            else if (val == _valueGear5)  _currentGear = 5;
+                            else if (val == _valueGear6)  _currentGear = 6;
+                            else                          _currentGear = 0;
+                        }
+                    }
+                    else
+                    {
+                        if (_gearByteIndex >= 0 && _gearByteIndex < (int)bytesRead)
+                        {
+                            int b = buffer[_gearByteIndex];
+                            if (_reverseBit >= 0 && (b & (1 << _reverseBit)) != 0)
+                                _currentGear = -1;
+                            else if (_gear1Bit >= 0 && (b & (1 << _gear1Bit)) != 0)
+                                _currentGear = 1;
+                            else if (_gear2Bit >= 0 && (b & (1 << _gear2Bit)) != 0)
+                                _currentGear = 2;
+                            else if (_gear3Bit >= 0 && (b & (1 << _gear3Bit)) != 0)
+                                _currentGear = 3;
+                            else if (_gear4Bit >= 0 && (b & (1 << _gear4Bit)) != 0)
+                                _currentGear = 4;
+                            else if (_gear5Bit >= 0 && (b & (1 << _gear5Bit)) != 0)
+                                _currentGear = 5;
+                            else if (_gear6Bit >= 0 && (b & (1 << _gear6Bit)) != 0)
+                                _currentGear = 6;
+                            else
+                                _currentGear = 0;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_running) Debug.LogError($"[HoriShifterReader] Poll exception: {ex.Message}");
+                break;
+            }
+        }
+        _running = false;
+        _connected = false;
+        _currentGear = 0;
+    }
+
+    void OnDestroy()
+    {
+        _running = false;
+        try { _hidHandle?.Dispose(); } catch { }
+        _hidHandle = null;
+        try { _pollerThread?.Join(500); } catch { }
+        _pollerThread = null;
+        if (Gley.UrbanSystem.UIInputNew.HoriShifterStateProvider != null)
+            Gley.UrbanSystem.UIInputNew.HoriShifterStateProvider = null;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Device enumeration: find the HORI shifter (PID 0x0186, col01)
+    // ─────────────────────────────────────────────────────────────────────
+
+    static string FindShifterPath()
+    {
+        var paths = EnumerateHidPaths();
+        string fallback = null;
+        foreach (var p in paths)
+        {
+            string lower = p.ToLowerInvariant();
+            if (!lower.Contains("vid_0f0d")) continue;
+            // Skip wheel device (PID 017A) — owned by HoriThrottleReader
+            if (lower.Contains("pid_017a")) continue;
+            // Prefer shifter PID 0186 col01 (game controller interface with gear data)
+            if (lower.Contains("pid_0186") && lower.Contains("col01"))
+                return p;
+            if (fallback == null)
+                fallback = p;
+        }
+        return fallback;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // P/Invoke — same as HoriThrottleReader/HoriShifterProbe
+    // ─────────────────────────────────────────────────────────────────────
+
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint FILE_SHARE_READ = 0x1;
+    private const uint FILE_SHARE_WRITE = 0x2;
+    private const uint OPEN_EXISTING = 3;
+    private const uint DIGCF_PRESENT = 0x2;
+    private const uint DIGCF_DEVICEINTERFACE = 0x10;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SP_DEVICE_INTERFACE_DATA { public int cbSize; public Guid g; public uint flags; public IntPtr reserved; }
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern IntPtr SetupDiGetClassDevs(ref Guid g, IntPtr enumerator, IntPtr hwndParent, uint flags);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiEnumDeviceInterfaces(IntPtr di, IntPtr deviceInfoData, ref Guid g, uint memberIndex, ref SP_DEVICE_INTERFACE_DATA o);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr di, ref SP_DEVICE_INTERFACE_DATA d, IntPtr buf, uint bufLen, ref uint required, IntPtr deviceInfo);
+
+    [DllImport("setupapi.dll")]
+    private static extern bool SetupDiDestroyDeviceInfoList(IntPtr di);
+
+    [DllImport("hid.dll")]
+    private static extern void HidD_GetHidGuid(out Guid g);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern SafeFileHandle CreateFile(string fileName, uint access, uint share, IntPtr sa, uint creation, uint flags, IntPtr template);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ReadFile(SafeFileHandle handle, [Out] byte[] buffer, uint numBytes, out uint bytesRead, IntPtr overlapped);
+
+    static List<string> EnumerateHidPaths()
+    {
+        var paths = new List<string>();
+        Guid g; HidD_GetHidGuid(out g);
+        IntPtr di = SetupDiGetClassDevs(ref g, IntPtr.Zero, IntPtr.Zero, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (di == new IntPtr(-1)) return paths;
+        try
+        {
+            uint i = 0;
+            while (true)
+            {
+                var sdid = new SP_DEVICE_INTERFACE_DATA();
+                sdid.cbSize = Marshal.SizeOf(typeof(SP_DEVICE_INTERFACE_DATA));
+                if (!SetupDiEnumDeviceInterfaces(di, IntPtr.Zero, ref g, i++, ref sdid)) break;
+                uint req = 0;
+                SetupDiGetDeviceInterfaceDetail(di, ref sdid, IntPtr.Zero, 0, ref req, IntPtr.Zero);
+                IntPtr buf = Marshal.AllocHGlobal((int)req);
+                try
+                {
+                    Marshal.WriteInt32(buf, IntPtr.Size == 8 ? 8 : 6);
+                    if (SetupDiGetDeviceInterfaceDetail(di, ref sdid, buf, req, ref req, IntPtr.Zero))
+                    {
+                        string p = Marshal.PtrToStringAuto(new IntPtr(buf.ToInt64() + 4));
+                        if (!string.IsNullOrEmpty(p)) paths.Add(p);
+                    }
+                }
+                finally { Marshal.FreeHGlobal(buf); }
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(di); }
+        return paths;
+    }
+
+#else
+    // Non-Windows stub (HORI HPC-044U is Windows-only).
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Bootstrap()
+    {
+        if (_instance != null) return;
+        var go = new GameObject("[HoriShifterReader]");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<HoriShifterReader>();
+        Gley.UrbanSystem.UIInputNew.HoriShifterStateProvider = () => int.MinValue;
+    }
+#endif
+}

--- a/2026MVP/Assets/Custom/HoriShifterReader.cs.meta
+++ b/2026MVP/Assets/Custom/HoriShifterReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb655fe2b70bb4d729317f07d3d3ff7e

--- a/2026MVP/Assets/Custom/HoriThrottleReader.cs
+++ b/2026MVP/Assets/Custom/HoriThrottleReader.cs
@@ -70,6 +70,17 @@ public class HoriThrottleReader : MonoBehaviour
     public float Value => _value;
     private volatile float _value;
 
+    /// <summary>True si el HID handle está abierto y el poller corriendo
+    /// (i.e., el reader puede entregar lecturas vivas). Codex review v3:
+    /// Pantalla 2 verifica este flag antes de validar el throttle, y
+    /// HoriThrottleReader.cs reintenta abrir el handle cada 2s post-bootstrap
+    /// si el wheel se conecta tarde (USB hot-plug). v1.6.5 (Fase B5).</summary>
+#if HORI_USE_PINVOKE
+    public bool IsHandleOpen => _running && _hidHandle != null && !_hidHandle.IsInvalid;
+#else
+    public bool IsHandleOpen => false;  // platforms sin P/Invoke (macOS/Linux build)
+#endif
+
 #if HORI_USE_PINVOKE
     private const int VID = 0x0F0D;
     private const int PID = 0x017A;

--- a/2026MVP/Assets/Custom/InputMath.meta
+++ b/2026MVP/Assets/Custom/InputMath.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7dfa12a0aeaf6853c29ce6f1b81db9a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Custom/InputMath/InputMath.cs
+++ b/2026MVP/Assets/Custom/InputMath/InputMath.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace TlaxSim.Input
+{
+    // Funciones puras de matemática de input. Aisladas de Unity Input System y
+    // de MonoBehaviour para que sean testeables en EditMode (no Mono lifecycle,
+    // no hardware, no async). El espejo en Gley.UrbanSystem.UIInputNew lo usa
+    // vía delegate injection (mismo patrón que HoriThrottleProvider) — ver
+    // RegisterImpl() abajo.
+    //
+    // Por qué este archivo existe: lección 4 de HORI_CALIBRATION_LESSONS.md
+    // ("Test unitario de NormalizePedal con casos extremos: divide-by-zero,
+    // span negativo, raw fuera de [rest, press], inversión de polaridad.
+    // Hubiera pillado el bug original sin necesidad de un kiosko").
+    public static class InputMath
+    {
+        /// <summary>
+        /// Normaliza un pedal raw a [0,1] usando rest+press calibrados.
+        /// Funciona sin importar dirección del eje (rest puede ser &gt; o &lt; press).
+        /// Retorna 0 si span (|press-rest|) es &lt; 0.05 (guard de divide-by-zero).
+        /// </summary>
+        public static float NormalizePedal(float raw, float rest, float press)
+        {
+            float span = press - rest;
+            if (Mathf.Abs(span) < 0.05f) return 0f;
+            return Mathf.Clamp01((raw - rest) / span);
+        }
+
+        // Inyecta esta implementación como la que usa UIInputNew en runtime, así
+        // garantizamos que tests y producción usan la misma fórmula. Si en
+        // futuro alguien cambia uno sin el otro, esto los re-sincroniza al boot.
+        // Cross-asmdef Custom→Gley está permitido (Custom referencia
+        // Gley.UrbanSystem; lo inverso no, por eso usamos delegate injection).
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void RegisterImpl()
+        {
+            Gley.UrbanSystem.UIInputNew.NormalizePedalImpl = NormalizePedal;
+        }
+    }
+}

--- a/2026MVP/Assets/Custom/InputMath/InputMath.cs.meta
+++ b/2026MVP/Assets/Custom/InputMath/InputMath.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d78e8183279e2912b9bbaa2341dfa230
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Custom/InputMath/TlaxSim.Input.asmdef
+++ b/2026MVP/Assets/Custom/InputMath/TlaxSim.Input.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "TlaxSim.Input",
+    "rootNamespace": "TlaxSim.Input",
+    "references": [
+        "Gley.UrbanSystem"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/2026MVP/Assets/Custom/InputMath/TlaxSim.Input.asmdef.meta
+++ b/2026MVP/Assets/Custom/InputMath/TlaxSim.Input.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a3206893263fb2415dd58df7d093c6d3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Custom/LogConsolePanel.cs
+++ b/2026MVP/Assets/Custom/LogConsolePanel.cs
@@ -262,7 +262,8 @@ public class LogConsolePanel : MonoBehaviour
             sb.Append("HoriThrottleReader".PadRight(22));
             sb.Append($" v=<color={HEX_VAL}>{thrInst.Value,7:F3}</color>");
             sb.Append($" base=<color={HEX_DIM}>{0f,6:F2}</color>");
-            sb.Append($" rango=<color={HEX_DIM}>[ 0.00,  1.00]</color>\n");
+            sb.Append($" rango=<color={HEX_DIM}>[ 0.00,  1.00]</color>");
+            sb.Append($" handle=<color={HEX_DIM}>{(thrInst.IsHandleOpen ? "open" : "CLOSED")}</color>\n");
         }
         else
         {

--- a/2026MVP/Assets/Custom/LogConsolePanel.cs
+++ b/2026MVP/Assets/Custom/LogConsolePanel.cs
@@ -247,6 +247,41 @@ public class LogConsolePanel : MonoBehaviour
             }
         }
 
+        // Custom HID readers (P/Invoke bypass de Unity Input System).
+        // El HORI HPC-044U declara 2 Sliders Usage 0x36 duplicados → Unity hace
+        // alias y deja el byte del throttle (21-22) huérfano: ningún AxisControl
+        // lo lee, por eso F7 nunca lo muestra en la sección de devices arriba.
+        // HoriThrottleReader / HoriShifterReader leen el HID directo via ReadFile.
+        // Mostrarlos aquí es el único lugar donde el operador puede confirmar que
+        // el throttle/shifter responde al pisar/mover.
+        sb.Append($"\n<color={HEX_HEADER}>// CUSTOM HID READERS</color>  <color={HEX_DIM}>(bypass del HID parser de Unity para HORI Truck)</color>\n");
+        var thrInst = HoriThrottleReader.Instance;
+        if (thrInst != null)
+        {
+            sb.Append($"   <color={HEX_AXIS}>AXIS</color> ");
+            sb.Append("HoriThrottleReader".PadRight(22));
+            sb.Append($" v=<color={HEX_VAL}>{thrInst.Value,7:F3}</color>");
+            sb.Append($" base=<color={HEX_DIM}>{0f,6:F2}</color>");
+            sb.Append($" rango=<color={HEX_DIM}>[ 0.00,  1.00]</color>\n");
+        }
+        else
+        {
+            sb.Append($"   <color={HEX_DIM}>HoriThrottleReader  &lt;no instance&gt;</color>\n");
+        }
+        var shfInst = HoriShifterReader.Instance;
+        if (shfInst != null)
+        {
+            sb.Append($"   <color={HEX_AXIS}>AXIS</color> ");
+            sb.Append("HoriShifterReader".PadRight(22));
+            sb.Append($" gear=<color={HEX_VAL}>{shfInst.CurrentGear,2}</color>");
+            sb.Append($" R=<color={HEX_DIM}>{shfInst.IsLeverInR}</color>");
+            sb.Append($" conn=<color={HEX_DIM}>{shfInst.IsConnected}</color>\n");
+        }
+        else
+        {
+            sb.Append($"   <color={HEX_DIM}>HoriShifterReader   &lt;no instance&gt;</color>\n");
+        }
+
         if (!anyDevice)
             sb.Append($"\n   <color={HEX_DIM}>Mueve cualquier eje o presiona cualquier botón</color>\n");
         return sb.ToString();

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -192,6 +192,11 @@ public class MenuScreenManager : MonoBehaviour
     private bool rightDone, leftDone;
     private bool throttleDone, brakeDone;
     private bool reverseDone;
+    // v1.6.5 (B5): timer para verificación del HoriThrottleReader en Phase 3 HORI.
+    // Reset a -1 en PrepareWheelScreen; se inicializa al primer frame que entra
+    // a Phase 3 con HORI conectado. Permite mostrar advertencia tras grace period
+    // si el reader no abre el HID handle (USB unplug, conflicto driver, etc.).
+    private float _horiPhase3StartTime = -1f;
     // Clutch phase: solo aplica si TransmisionManual==1 && IsHORITruck.
     // En G923 (PS y Xbox v1.5.7+) el clutch lo siembra
     // SeedG923VariantDefaultsIfMissing; en automático no hay clutch. Por eso
@@ -2172,6 +2177,7 @@ public class MenuScreenManager : MonoBehaviour
         reverseDone = reverseCal;
         clutchDone = !clutchPhaseNeeded;
         _brakeChosenIdx = -1; // se llenará en la phase brake (Update)
+        _horiPhase3StartTime = -1f; // v1.6.5 (B5): timer reseteado al re-prepare
 
         // Reset deltas de candidatos para esta sesión de calibración
         if (pedalCandidateMaxDeltas != null)
@@ -2441,38 +2447,81 @@ public class MenuScreenManager : MonoBehaviour
         // |delta| desde su reposo (capturado al inicio de la fase).
         if (!throttleDone)
         {
-            #region HORI HPC-044U gas phase auto-pass — DO NOT MODIFY (ver HORI_THROTTLE_BUG_RESOLUTION.md, PR #127)
-            // ⚠️ CRITICAL — Sin este auto-pass, Pantalla 2 Discovery se atora
-            //   en Phase 3 con el HORI Truck Control System: el throttle del
-            //   HORI vive en un byte huérfano del HID report (Unity HID parser
-            //   bug por sliders duplicados Usage 0x36) y NINGÚN candidate de
-            //   PEDAL_AXIS_CANDIDATES detecta el delta cuando el usuario pisa
-            //   el acelerador. Sin auto-pass el operador queda bloqueado en la
-            //   pantalla de calibración SIN poder avanzar al examen.
+            #region HORI HPC-044U gas phase verify — v1.6.5 (Fase B5)
+            // El throttle del HORI vive en un byte huérfano del HID report
+            // (Unity HID parser bug por sliders duplicados Usage 0x36); ningún
+            // PEDAL_AXIS_CANDIDATES lo detecta. v1.5.12 auto-pasaba esta fase
+            // sin verificación → si HoriThrottleReader fallaba al inicializar
+            // (USB hot-plug, driver conflict), el operador llegaba a la escena
+            // con throttle silente y no había forma de saberlo en Pantalla 2.
+            //
+            // v1.6.5 (B5): NO auto-pasamos. Verificamos en vivo que el reader:
+            //   (a) tenga el HID handle abierto (IsHandleOpen)
+            //   (b) reporte un valor > HORI_THROTTLE_VERIFY_THRESHOLD (0.7)
+            //       cuando el operador pise el pedal.
+            // Si después de HORI_READER_GRACE_SECONDS (8s) el handle no abrió,
+            // mostramos advertencia visible en el prompt — el reader sigue
+            // intentando reabrir cada 2s (HoriThrottleReader.Update retry loop)
+            // así que conectar el USB recupera la fase. F7 también muestra
+            // `handle=open|CLOSED` para diagnóstico paralelo (Fase A).
+            //
             // El throttle se lee en runtime via HoriThrottleReader (P/Invoke
             // directo al HID device). UIInputNew.AttachToWheelDevice setea el
-            // sentinel también — esto es REDUNDANCIA defensiva por si Pantalla 2
-            // corre antes que AttachToWheelDevice (orden de bootstrap).
-            // NO eliminar.
-            //
-            // HORI Truck workaround: el byte del throttle (HID 21-22) quedó
-            // huérfano en el HID parser de Unity (no hay AxisControl que lo
-            // lea — verificado raw HID dump 2026-05-03). Auto-pasamos esta
-            // fase y dejamos que HoriThrottleReader.cs lea el byte directo
-            // via InputSystem.onEvent intercept. Sentinel HORI_RAW_GAS_PATH.
+            // sentinel; aquí escribimos las prefs solo cuando la verificación
+            // pasa (no antes — evita marcar Phase 3 done con reader muerto).
             var devForGas = TryAttachToDevice();
             if (devForGas != null && UIInputNew.IsHORITruck(devForGas))
             {
-                throttleDone = true;
-                gasFillRT.anchorMax = new Vector2(1, 1);
-                gasFill.color = MenuTheme.IndicatorDone;
-                gasIndicator.color = MenuTheme.IndicatorDone;
-                PlayerPrefs.SetString("G923_GasAxis", UIInputNew.HORI_RAW_GAS_PATH);
-                PlayerPrefs.SetFloat("G923_GasRest", 0f);
-                PlayerPrefs.SetFloat("G923_GasPress", 1f);
-                Debug.Log($"[MenuScreenManager] HORI Truck — gas phase auto-pasada, throttle vía HoriThrottleReader (sentinel '{UIInputNew.HORI_RAW_GAS_PATH}')");
-                wheelPrompt.text = "Pisa el FRENO a fondo";
+                if (_horiPhase3StartTime < 0f) _horiPhase3StartTime = Time.unscaledTime;
+                float horiPhase3Elapsed = Time.unscaledTime - _horiPhase3StartTime;
+
+                var thrReader = HoriThrottleReader.Instance;
+                float thrValue = thrReader != null ? thrReader.Value : 0f;
+                bool thrHandleOpen = thrReader != null && thrReader.IsHandleOpen;
+
+                // Progress bar en vivo basada en el valor del reader.
+                float gasProgress = Mathf.Clamp01(thrValue);
+                if (Mathf.Abs(gasProgress - gasFillRT.anchorMax.x) > 0.005f)
+                {
+                    gasFillRT.anchorMax = new Vector2(gasProgress, 1);
+                    gasFill.color = Color.Lerp(MenuTheme.SecondaryCrimson, MenuTheme.IndicatorDone, gasProgress);
+                }
+
+                const float HORI_THROTTLE_VERIFY_THRESHOLD = 0.7f;
+                const float HORI_READER_GRACE_SECONDS = 8f;
+
+                if (thrHandleOpen && thrValue >= HORI_THROTTLE_VERIFY_THRESHOLD)
+                {
+                    throttleDone = true;
+                    gasFillRT.anchorMax = new Vector2(1, 1);
+                    gasFill.color = MenuTheme.IndicatorDone;
+                    gasIndicator.color = MenuTheme.IndicatorDone;
+                    PlayerPrefs.SetString("G923_GasAxis", UIInputNew.HORI_RAW_GAS_PATH);
+                    PlayerPrefs.SetFloat("G923_GasRest", 0f);
+                    PlayerPrefs.SetFloat("G923_GasPress", 1f);
+                    PlayerPrefs.Save();
+                    Debug.Log($"[MenuScreenManager] HORI Truck — gas phase VERIFICADA via HoriThrottleReader (value={thrValue:F3}, handle=open, elapsed={horiPhase3Elapsed:F1}s)");
+                    wheelPrompt.text = "Pisa el FRENO a fondo";
+                    _horiPhase3StartTime = -1f;
+                    return;
+                }
+
+                // Reader muerto tras grace period — advertencia visible. El
+                // reader sigue reintentando cada 2s; conectar USB recupera.
+                if (!thrHandleOpen && horiPhase3Elapsed > HORI_READER_GRACE_SECONDS)
+                {
+                    if (wheelPrompt.text != "HoriThrottleReader sin handle - verifica USB del HORI Truck")
+                    {
+                        Debug.LogWarning($"[MenuScreenManager] HORI Truck — HoriThrottleReader sin handle abierto tras {HORI_READER_GRACE_SECONDS}s. El reader sigue intentando reabrir cada 2s.");
+                        wheelPrompt.text = "HoriThrottleReader sin handle - verifica USB del HORI Truck";
+                    }
+                }
                 return;
+            }
+            else
+            {
+                // Reset al salir del path HORI (cambio de hardware mid-flow).
+                _horiPhase3StartTime = -1f;
             }
             #endregion
             int bestIdx = SamplePedalCandidates(-1, out float bestAbsDelta);

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -2104,6 +2104,53 @@ public class MenuScreenManager : MonoBehaviour
             ClearWheelCalibration();
         }
 
+        // v1.6.3 (HORI migration): la calibración guardada en kioskos pre-fix
+        // (Pasajeros 1 + Pasajeros 2 confirmados 2026-05-08) tiene axis válido
+        // (rz/slider/slider1) pero rest/press corruptos:
+        //   Pasajeros 2: rest=1.0, press=0.0 → span=-1, NormalizePedal(raw=-1)=2 → clamp=1 → freno pegado.
+        //   Pasajeros 1: rest=0.0, press=0.0 → span=0 < guard 0.05 → NormalizePedal=0 (freno OK)
+        //                 PERO clutch rest=0.0/press=2.0 → press fuera de rango → bloquea shifts.
+        // HORI sano debería ser rest=-1.0, press=+1.0 → span≈2.0. Detectar tres modos
+        // de calibración rota en boot y forzar re-Discovery del axis afectado.
+        // Solo HORI (G923 mantiene comportamiento — sus axes son estables).
+        if (fingerprintMatches && UIInputNew.IsHORITruck(dev))
+        {
+            void InvalidateIfBad(string axisKey, string restKey, string pressKey, string label)
+            {
+                if (!PlayerPrefs.HasKey(axisKey)) return;
+                string savedAxis = PlayerPrefs.GetString(axisKey, "");
+                float rest = PlayerPrefs.GetFloat(restKey, 0f);
+                float press = PlayerPrefs.GetFloat(pressKey, 0f);
+                bool axisInvalid = !string.IsNullOrEmpty(savedAxis)
+                    && savedAxis != UIInputNew.HORI_RAW_GAS_PATH
+                    && !HORI_PEDAL_AXIS_WHITELIST.Contains(savedAxis);
+                // Threshold 1.5: HORI sano = span≈2.0; rest=1/press=0 = span=1.0 (capturado);
+                // rest=0/press=0 = span=0 (capturado). G923 PS brake (rest=1, press=-1) =
+                // span=2.0 también, pero G923 no entra a este bloque por el if IsHORITruck.
+                bool spanInsufficient = Mathf.Abs(press - rest) < 1.5f;
+                bool restOutOfRange = Mathf.Abs(rest) > 1.1f;
+                bool pressOutOfRange = Mathf.Abs(press) > 1.1f;
+                if (axisInvalid || spanInsufficient || restOutOfRange || pressOutOfRange)
+                {
+                    Debug.LogWarning($"[MenuScreenManager] HORI {label} calibración inválida: "
+                        + $"axis='{savedAxis}' rest={rest:F3} press={press:F3} "
+                        + $"(axisInvalid={axisInvalid} span={Mathf.Abs(press-rest):F3} "
+                        + $"restRange={restOutOfRange} pressRange={pressOutOfRange}) — "
+                        + $"invalidando para re-Discovery en Pantalla 2");
+                    PlayerPrefs.DeleteKey(axisKey);
+                    PlayerPrefs.DeleteKey(restKey);
+                    PlayerPrefs.DeleteKey(pressKey);
+                }
+            }
+            InvalidateIfBad("G923_BrakeAxis", "G923_BrakeRest", "G923_BrakePress", "BRAKE");
+            // Gas: para HORI el axis es siempre el sentinel HORI_RAW_GAS_PATH
+            // (HoriThrottleReader bypassa NormalizePedal vía P/Invoke). rest=0/press=0
+            // del sentinel son cosméticos. NO llamar InvalidateIfBad — el spanInsufficient
+            // dispararía falsamente y forzaría re-Discovery innecesaria (HORI gas se auto-pasa).
+            InvalidateIfBad(UIInputNew.PREF_G923_CLUTCH_AXIS, UIInputNew.PREF_G923_CLUTCH_REST, UIInputNew.PREF_G923_CLUTCH_PRESS, "CLUTCH");
+            PlayerPrefs.Save();
+        }
+
         // ── 2) Calcular qué fases ya tienen calibración válida ──
         bool steeringCal = fingerprintMatches
             && PlayerPrefs.HasKey("G923_SteerMax") && PlayerPrefs.HasKey("G923_SteerMin");

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -91,6 +91,19 @@ public class MenuScreenManager : MonoBehaviour
     private static readonly string[] PEDAL_AXIS_CANDIDATES = {
         "z", "rz", "stick/y", "stick/z", "ry", "rx", "slider", "slider1"
     };
+    // HORI Truck HPC-044U: la pedalera real está SOLO en rz/slider/slider1.
+    // Los demás candidatos (z/stick/y/stick/z/ry/rx) reportan jitter HID
+    // de axes fantasma y pueden ganar el max-delta de Discovery si el
+    // operador no presiona el pedal exacto en el instante preciso, dejando
+    // G923_BrakeAxis apuntando a un axis no-pedal con polaridad invertida.
+    // Resultado runtime: B=1.0 con raw=0 (freno "pegado") → en Auto el carro
+    // no se mueve aunque el throttle esté al fondo. Confirmado en Pasajeros 2
+    // (logs S3 2026-05-08, sesiones consecutivas con brake bound a 'z' y
+    // 'slider' alternadamente). G923 no aplica este filtro: usa la lista
+    // completa porque sus axes en rest son estables.
+    private static readonly HashSet<string> HORI_PEDAL_AXIS_WHITELIST = new HashSet<string> {
+        "rz", "slider", "slider1"
+    };
     private InputControl<float>[] pedalCandidates;
     // Calibración por delta signado desde el reposo — funciona con ejes
     // cuyo rest sea +1, 0 o -1, y en cualquier dirección de press.
@@ -2665,12 +2678,22 @@ public class MenuScreenManager : MonoBehaviour
         pedalCandidates = new InputControl<float>[PEDAL_AXIS_CANDIDATES.Length];
         pedalCandidateRests = new float[PEDAL_AXIS_CANDIDATES.Length];
         pedalCandidateMaxDeltas = new float[PEDAL_AXIS_CANDIDATES.Length];
+        bool isHori = device != null && UIInputNew.IsHORITruck(device);
+        int horiRejected = 0;
         for (int i = 0; i < PEDAL_AXIS_CANDIDATES.Length; i++)
         {
-            pedalCandidates[i] = device.TryGetChildControl(PEDAL_AXIS_CANDIDATES[i]) as InputControl<float>;
+            var ctrl = device.TryGetChildControl(PEDAL_AXIS_CANDIDATES[i]) as InputControl<float>;
+            if (isHori && ctrl != null && !HORI_PEDAL_AXIS_WHITELIST.Contains(PEDAL_AXIS_CANDIDATES[i]))
+            {
+                ctrl = null;
+                horiRejected++;
+            }
+            pedalCandidates[i] = ctrl;
             pedalCandidateRests[i] = 1f; // placeholder hasta snapshot
             pedalCandidateMaxDeltas[i] = 0f;
         }
+        if (isHori && horiRejected > 0)
+            Debug.Log($"[MenuScreenManager] HORI Truck — Discovery limitada a {string.Join(",", HORI_PEDAL_AXIS_WHITELIST)} (rechazados {horiRejected} axes fantasma)");
     }
 
     // Captura el valor de reposo de cada candidato. Llamar justo antes de la

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -2104,52 +2104,9 @@ public class MenuScreenManager : MonoBehaviour
             ClearWheelCalibration();
         }
 
-        // v1.6.3 (HORI migration): la calibración guardada en kioskos pre-fix
-        // (Pasajeros 1 + Pasajeros 2 confirmados 2026-05-08) tiene axis válido
-        // (rz/slider/slider1) pero rest/press corruptos:
-        //   Pasajeros 2: rest=1.0, press=0.0 → span=-1, NormalizePedal(raw=-1)=2 → clamp=1 → freno pegado.
-        //   Pasajeros 1: rest=0.0, press=0.0 → span=0 < guard 0.05 → NormalizePedal=0 (freno OK)
-        //                 PERO clutch rest=0.0/press=2.0 → press fuera de rango → bloquea shifts.
-        // HORI sano debería ser rest=-1.0, press=+1.0 → span≈2.0. Detectar tres modos
-        // de calibración rota en boot y forzar re-Discovery del axis afectado.
-        // Solo HORI (G923 mantiene comportamiento — sus axes son estables).
-        if (fingerprintMatches && UIInputNew.IsHORITruck(dev))
-        {
-            void InvalidateIfBad(string axisKey, string restKey, string pressKey, string label)
-            {
-                if (!PlayerPrefs.HasKey(axisKey)) return;
-                string savedAxis = PlayerPrefs.GetString(axisKey, "");
-                float rest = PlayerPrefs.GetFloat(restKey, 0f);
-                float press = PlayerPrefs.GetFloat(pressKey, 0f);
-                bool axisInvalid = !string.IsNullOrEmpty(savedAxis)
-                    && savedAxis != UIInputNew.HORI_RAW_GAS_PATH
-                    && !HORI_PEDAL_AXIS_WHITELIST.Contains(savedAxis);
-                // Threshold 1.5: HORI sano = span≈2.0; rest=1/press=0 = span=1.0 (capturado);
-                // rest=0/press=0 = span=0 (capturado). G923 PS brake (rest=1, press=-1) =
-                // span=2.0 también, pero G923 no entra a este bloque por el if IsHORITruck.
-                bool spanInsufficient = Mathf.Abs(press - rest) < 1.5f;
-                bool restOutOfRange = Mathf.Abs(rest) > 1.1f;
-                bool pressOutOfRange = Mathf.Abs(press) > 1.1f;
-                if (axisInvalid || spanInsufficient || restOutOfRange || pressOutOfRange)
-                {
-                    Debug.LogWarning($"[MenuScreenManager] HORI {label} calibración inválida: "
-                        + $"axis='{savedAxis}' rest={rest:F3} press={press:F3} "
-                        + $"(axisInvalid={axisInvalid} span={Mathf.Abs(press-rest):F3} "
-                        + $"restRange={restOutOfRange} pressRange={pressOutOfRange}) — "
-                        + $"invalidando para re-Discovery en Pantalla 2");
-                    PlayerPrefs.DeleteKey(axisKey);
-                    PlayerPrefs.DeleteKey(restKey);
-                    PlayerPrefs.DeleteKey(pressKey);
-                }
-            }
-            InvalidateIfBad("G923_BrakeAxis", "G923_BrakeRest", "G923_BrakePress", "BRAKE");
-            // Gas: para HORI el axis es siempre el sentinel HORI_RAW_GAS_PATH
-            // (HoriThrottleReader bypassa NormalizePedal vía P/Invoke). rest=0/press=0
-            // del sentinel son cosméticos. NO llamar InvalidateIfBad — el spanInsufficient
-            // dispararía falsamente y forzaría re-Discovery innecesaria (HORI gas se auto-pasa).
-            InvalidateIfBad(UIInputNew.PREF_G923_CLUTCH_AXIS, UIInputNew.PREF_G923_CLUTCH_REST, UIInputNew.PREF_G923_CLUTCH_PRESS, "CLUTCH");
-            PlayerPrefs.Save();
-        }
+        // v1.6.4: la migración v1.6.3 que invalidaba prefs HORI corruptas se removió:
+        // ahora UIInputNew.AttachToWheelDevice ignora PlayerPrefs G923_*Rest/Press para
+        // HORI y usa hardcoded -1/+1. Lo que quede en registry no afecta runtime HORI.
 
         // ── 2) Calcular qué fases ya tienen calibración válida ──
         bool steeringCal = fingerprintMatches
@@ -3427,9 +3384,14 @@ public class MenuScreenManager : MonoBehaviour
             PlayerPrefs.Save();
         }
 
-        float gasRest = PlayerPrefs.GetFloat("G923_GasRest", 0f);
-        float brakeRest = PlayerPrefs.GetFloat("G923_BrakeRest", 0f);
-        float clutchRest = PlayerPrefs.GetFloat(UIInputNew.PREF_G923_CLUTCH_REST, -1f);
+        // HORI Truck pedales son hardware-fijos (rest=-1, press=+1); no leer de PlayerPrefs.
+        // Si llegamos aquí con HORI y los rest/press de PlayerPrefs estuvieran corruptos
+        // (registry contaminado de versiones previas), el sanity check usaría valores
+        // erróneos y haría delete-cycle infinito. Hardcoded para evitarlo.
+        bool isHori = dev != null && UIInputNew.IsHORITruck(dev);
+        float gasRest    = isHori ? 0f  : PlayerPrefs.GetFloat("G923_GasRest", 0f);
+        float brakeRest  = isHori ? -1f : PlayerPrefs.GetFloat("G923_BrakeRest", 0f);
+        float clutchRest = isHori ? -1f : PlayerPrefs.GetFloat(UIInputNew.PREF_G923_CLUTCH_REST, -1f);
 
         // v1.5.12 (Cambio 2): sanity check NO-destructiva. Antes hacía
         // ClearWheelCalibration() global con cualquier delta > 0.5, y un pie

--- a/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
+++ b/2026MVP/Assets/Custom/Menu/MenuScreenManager.cs
@@ -2109,11 +2109,20 @@ public class MenuScreenManager : MonoBehaviour
         // HORI y usa hardcoded -1/+1. Lo que quede en registry no afecta runtime HORI.
 
         // ── 2) Calcular qué fases ya tienen calibración válida ──
+        bool isHoriDevice = dev != null && UIInputNew.IsHORITruck(dev);
+
         bool steeringCal = fingerprintMatches
             && PlayerPrefs.HasKey("G923_SteerMax") && PlayerPrefs.HasKey("G923_SteerMin");
+
+        // Para HORI los pedales son hardware-fijos (rest/press hardcoded en
+        // UIInputNew v1.6.4) — solo el axis path importa para considerar la
+        // calibración válida. Para G923/otros sí necesitamos rest/press persistidos.
         bool pedalsCal = fingerprintMatches
-            && PlayerPrefs.HasKey("G923_GasAxis")   && PlayerPrefs.HasKey("G923_GasRest")   && PlayerPrefs.HasKey("G923_GasPress")
-            && PlayerPrefs.HasKey("G923_BrakeAxis") && PlayerPrefs.HasKey("G923_BrakeRest") && PlayerPrefs.HasKey("G923_BrakePress");
+            && PlayerPrefs.HasKey("G923_GasAxis") && PlayerPrefs.HasKey("G923_BrakeAxis")
+            && (isHoriDevice || (
+                PlayerPrefs.HasKey("G923_GasRest")   && PlayerPrefs.HasKey("G923_GasPress")
+                && PlayerPrefs.HasKey("G923_BrakeRest") && PlayerPrefs.HasKey("G923_BrakePress")
+            ));
         bool reverseCal = fingerprintMatches && PlayerPrefs.GetInt(PREF_CAL_REVERSE_DONE, 0) == 1;
 
         // Clutch phase: solo HORI + Manual + sin clutch axis válido. G923 PS
@@ -2123,11 +2132,15 @@ public class MenuScreenManager : MonoBehaviour
         // El axis del clutch HORI no se puede hardcodear porque Unity alias
         // slider/slider1/rz arbitrariamente entre brake y clutch (ver
         // HORI_THROTTLE_BUG_RESOLUTION.md). Por eso lo descubrimos pisando.
+        // Para HORI, mismo criterio que pedalsCal: solo axis path (rest/press
+        // hardware-fijos hardcoded en UIInputNew).
         bool clutchPathPersisted = fingerprintMatches
             && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_AXIS)
             && !string.IsNullOrEmpty(PlayerPrefs.GetString(UIInputNew.PREF_G923_CLUTCH_AXIS, ""))
-            && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_REST)
-            && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_PRESS);
+            && (isHoriDevice || (
+                PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_REST)
+                && PlayerPrefs.HasKey(UIInputNew.PREF_G923_CLUTCH_PRESS)
+            ));
         bool clutchAlreadyCal = clutchPathPersisted;
         // v1.5.12 (Cambio 1 extendido): si clutchPath persistido pero el control
         // ya no resuelve en el device actual (e.g., HORI en otro USB con axis
@@ -2512,11 +2525,21 @@ public class MenuScreenManager : MonoBehaviour
                 brakeIndicator.color = MenuTheme.IndicatorDone;
 
                 PlayerPrefs.SetString("G923_BrakeAxis", brakeAxisPath);
-                PlayerPrefs.SetFloat("G923_BrakeRest", rest);
-                PlayerPrefs.SetFloat("G923_BrakePress", press);
+                // Para HORI los pedales son hardware-fijos (rest=-1, press=+1)
+                // y v1.6.4 los hardcodea en UIInputNew → no escribimos basura
+                // del Discovery a las prefs (lección 3 de HORI_CALIBRATION_LESSONS.md).
+                // Solo persistimos el axis path porque Unity puede aliasear
+                // slider/slider1/rz arbitrariamente entre boots.
+                var devForBrakeWrite = TryAttachToDevice();
+                bool isHoriBrake = devForBrakeWrite != null && UIInputNew.IsHORITruck(devForBrakeWrite);
+                if (!isHoriBrake)
+                {
+                    PlayerPrefs.SetFloat("G923_BrakeRest", rest);
+                    PlayerPrefs.SetFloat("G923_BrakePress", press);
+                }
                 // Reescribir la huella aquí también garantiza que un Partial
                 // que solo redescubrió pedales quede asociado al device actual.
-                string fpBrake = ComputeDeviceFingerprint(TryAttachToDevice());
+                string fpBrake = ComputeDeviceFingerprint(devForBrakeWrite);
                 if (!string.IsNullOrEmpty(fpBrake)) PlayerPrefs.SetString(PREF_CAL_FINGERPRINT, fpBrake);
                 PlayerPrefs.Save();
                 Debug.Log($"[MenuScreenManager] Freno → eje '{brakeAxisPath}' rest={rest:F3} press={press:F3} fp={fpBrake}");
@@ -2578,9 +2601,16 @@ public class MenuScreenManager : MonoBehaviour
                 brakeIndicator.color = MenuTheme.IndicatorDone;
 
                 PlayerPrefs.SetString(UIInputNew.PREF_G923_CLUTCH_AXIS, clutchAxisPath);
-                PlayerPrefs.SetFloat(UIInputNew.PREF_G923_CLUTCH_REST, rest);
-                PlayerPrefs.SetFloat(UIInputNew.PREF_G923_CLUTCH_PRESS, press);
-                string fpClutch = ComputeDeviceFingerprint(TryAttachToDevice());
+                // HORI clutch hardware-fijo a rest=-1/press=+1 (UIInputNew v1.6.4
+                // hardcodea). Skip writes de rest/press para evitar basura.
+                var devForClutchWrite = TryAttachToDevice();
+                bool isHoriClutch = devForClutchWrite != null && UIInputNew.IsHORITruck(devForClutchWrite);
+                if (!isHoriClutch)
+                {
+                    PlayerPrefs.SetFloat(UIInputNew.PREF_G923_CLUTCH_REST, rest);
+                    PlayerPrefs.SetFloat(UIInputNew.PREF_G923_CLUTCH_PRESS, press);
+                }
+                string fpClutch = ComputeDeviceFingerprint(devForClutchWrite);
                 if (!string.IsNullOrEmpty(fpClutch)) PlayerPrefs.SetString(PREF_CAL_FINGERPRINT, fpClutch);
                 PlayerPrefs.Save();
                 Debug.Log($"[MenuScreenManager] Embrague → eje '{clutchAxisPath}' rest={rest:F3} press={press:F3} fp={fpClutch}");
@@ -3392,6 +3422,50 @@ public class MenuScreenManager : MonoBehaviour
         float gasRest    = isHori ? 0f  : PlayerPrefs.GetFloat("G923_GasRest", 0f);
         float brakeRest  = isHori ? -1f : PlayerPrefs.GetFloat("G923_BrakeRest", 0f);
         float clutchRest = isHori ? -1f : PlayerPrefs.GetFloat(UIInputNew.PREF_G923_CLUTCH_REST, -1f);
+
+        // v1.6.5 (B3): hardware-aware sanity check para HORI brake/clutch. Los
+        // pedales HORI viven en axes con rango [-1, +1] (HID LE16 unsigned →
+        // Unity normalized). Si el axis raw cae consistentemente fuera de
+        // [-1.05, +1.05] durante 3 frames, eso significa "axis path incorrecto"
+        // (Discovery capturó otro axis), no "operador tocando el pedal" — invalidar
+        // SOLO el path para forzar Phase 4/6 dirigida. Window de 3 frames evita
+        // falsos positivos por jitter post-attach.
+        // No aplica a gas (HORI gas es sentinel via HoriThrottleReader, no pasa
+        // por SafeReadFloatRaw). No aplica a G923 (rangos varían por variante).
+        if (isHori)
+        {
+            const float HORI_AXIS_LO = -1.05f, HORI_AXIS_HI = 1.05f;
+            const int OUT_OF_RANGE_FRAMES_REQUIRED = 3;
+            int brakeOutOfRange = 0, clutchOutOfRange = 0;
+            for (int i = 0; i < OUT_OF_RANGE_FRAMES_REQUIRED; i++)
+            {
+                if (SafeReadFloatRaw(brakeC, out var bv))
+                {
+                    if (bv < HORI_AXIS_LO || bv > HORI_AXIS_HI) brakeOutOfRange++;
+                }
+                if (clutchC != null && SafeReadFloatRaw(clutchC, out var cv))
+                {
+                    if (cv < HORI_AXIS_LO || cv > HORI_AXIS_HI) clutchOutOfRange++;
+                }
+                yield return null;
+            }
+            if (brakeOutOfRange >= OUT_OF_RANGE_FRAMES_REQUIRED)
+            {
+                Debug.LogWarning($"[MenuScreenManager] HORI brake axis '{brakePath}' raw consistente fuera de [-1, +1] ({OUT_OF_RANGE_FRAMES_REQUIRED}/{OUT_OF_RANGE_FRAMES_REQUIRED} frames) → axis path probablemente incorrecto, invalidando para forzar re-Discovery de freno");
+                PlayerPrefs.DeleteKey("G923_BrakeAxis");
+                PlayerPrefs.Save();
+                PrepareWheelScreen();
+                yield break;
+            }
+            if (needClutch && clutchOutOfRange >= OUT_OF_RANGE_FRAMES_REQUIRED)
+            {
+                Debug.LogWarning($"[MenuScreenManager] HORI clutch axis '{clutchPath}' raw consistente fuera de [-1, +1] → invalidar para forzar re-Discovery de clutch");
+                PlayerPrefs.DeleteKey(UIInputNew.PREF_G923_CLUTCH_AXIS);
+                PlayerPrefs.Save();
+                PrepareWheelScreen();
+                yield break;
+            }
+        }
 
         // v1.5.12 (Cambio 2): sanity check NO-destructiva. Antes hacía
         // ClearWheelCalibration() global con cualquier delta > 0.5, y un pie

--- a/2026MVP/Assets/Custom/SimulatorApiClient.cs
+++ b/2026MVP/Assets/Custom/SimulatorApiClient.cs
@@ -608,6 +608,15 @@ public static class SimulatorApiClient
 
     private static CalibrationPayload BuildCalibrationPayload()
     {
+        // HORI Truck pedales son hardware-fijos (rest=-1, press=+1) y v1.6.4 los
+        // hardcodea en UIInputNew. Las PlayerPrefs G923_*Rest/Press pueden quedar
+        // basura del Discovery (v1.6.5 ya no las escribe para HORI, pero kioskos
+        // existentes pueden tener stale values pre-OTA). Para diagnóstico claro
+        // en el portal, reportar canónico cuando detectamos HORI por su sentinel
+        // de gas. Sentinel: G923_GasAxis == "__HORI_RAW_HID_THROTTLE__".
+        bool isHori = PlayerPrefs.GetString("G923_GasAxis", "")
+                      == Gley.UrbanSystem.UIInputNew.HORI_RAW_GAS_PATH;
+
         return new CalibrationPayload
         {
             deviceFingerprint    = PlayerPrefs.GetString("Cal_DeviceFingerprint", ""),
@@ -621,11 +630,11 @@ public static class SimulatorApiClient
             steerMax             = PlayerPrefs.GetFloat("G923_SteerMax", 0f),
             steerMin             = PlayerPrefs.GetFloat("G923_SteerMin", 0f),
             gasAxis              = PlayerPrefs.GetString("G923_GasAxis", ""),
-            gasRest              = PlayerPrefs.GetFloat("G923_GasRest", 0f),
-            gasPress             = PlayerPrefs.GetFloat("G923_GasPress", 0f),
+            gasRest              = isHori ? 0f : PlayerPrefs.GetFloat("G923_GasRest", 0f),
+            gasPress             = isHori ? 1f : PlayerPrefs.GetFloat("G923_GasPress", 0f),
             brakeAxis            = PlayerPrefs.GetString("G923_BrakeAxis", ""),
-            brakeRest            = PlayerPrefs.GetFloat("G923_BrakeRest", 0f),
-            brakePress           = PlayerPrefs.GetFloat("G923_BrakePress", 0f),
+            brakeRest            = isHori ? -1f : PlayerPrefs.GetFloat("G923_BrakeRest", 0f),
+            brakePress           = isHori ?  1f : PlayerPrefs.GetFloat("G923_BrakePress", 0f),
             advSteerCurveA       = PlayerPrefs.GetFloat("Adv_SteerCurveA", 1f),
             advSteerDeadzone     = PlayerPrefs.GetFloat("Adv_SteerDeadzone", 0.02f),
             advBrakeSoftEnd      = PlayerPrefs.GetFloat("Adv_BrakeSoftEnd", 0.8f),

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -1002,6 +1002,33 @@ namespace Gley.UrbanSystem
 
         public static bool IsHORITruck(InputDevice d)
         {
+            if (d == null) return false;
+
+            // Path 1: VID + PID + interfaceName HID. Más robusto que match por
+            // strings — Windows puede normalizar/truncar displayName y dejar
+            // un HORI sin "HORI" en el nombre (lección v1.6.4).
+            // HORI HPC-044U wheel: VID=0x0F0D PID=0x017A. Shifter: PID=0x0186.
+            if (d.description.interfaceName == "HID" &&
+                !string.IsNullOrEmpty(d.description.capabilities))
+            {
+                try
+                {
+                    var caps = UnityEngine.InputSystem.HID.HID.HIDDeviceDescriptor.FromJson(
+                        d.description.capabilities);
+                    const int HORI_VID = 0x0F0D;
+                    if (caps.vendorId == HORI_VID &&
+                        (caps.productId == 0x017A || caps.productId == 0x0186))
+                    {
+                        return true;
+                    }
+                }
+                catch (System.Exception)
+                {
+                    // JSON malformed — fallthrough al match por strings.
+                }
+            }
+
+            // Path 2: displayName/product fallback (preserva v1.6.4 si VID falla).
             string name = d.displayName ?? string.Empty;
             string product = d.description.product ?? string.Empty;
             return name.IndexOf("HORI", System.StringComparison.OrdinalIgnoreCase) >= 0
@@ -1508,12 +1535,22 @@ namespace Gley.UrbanSystem
 
         // Normaliza pedal a [0,1] usando rest+press calibrados en pantalla.
         // Funciona sin importar la dirección del eje (rest puede ser > o < press).
+        // v1.6.5: implementación delegada a TlaxSim.Input.InputMath (Assets/Custom/),
+        // que también es testeada en EditMode. El default inline aquí es idéntico,
+        // así que si InputMath no inyecta su impl (build de Editor sin Custom o
+        // similar), el comportamiento runtime no cambia. Cross-asmdef Custom→Gley
+        // está permitido; lo inverso no, por eso usamos delegate injection (mismo
+        // patrón que HoriThrottleProvider).
+        public static System.Func<float, float, float, float> NormalizePedalImpl =
+            (raw, rest, press) =>
+            {
+                float span = press - rest;
+                if (Mathf.Abs(span) < 0.05f) return 0f;
+                return Mathf.Clamp01((raw - rest) / span);
+            };
+
         private float NormalizePedal(float raw, float rest, float press)
-        {
-            float span = press - rest;
-            if (Mathf.Abs(span) < 0.05f) return 0f;
-            return Mathf.Clamp01((raw - rest) / span);
-        }
+            => NormalizePedalImpl(raw, rest, press);
 
         // Adopta un Moto Simulator (ESP32-S3 USB HID) como wheelDevice. Bypassa
         // la heurística axisCount/buttonCount (solo expone 2 botones). Cachea

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -1445,42 +1445,29 @@ namespace Gley.UrbanSystem
             }
             if (_isAutomaticMode && _currentGear == 0) _currentGear = 1;
 
-            // Cargar calibración de pedales (rest+press) hecha en el menú.
-            _gasRest    = PlayerPrefs.GetFloat("G923_GasRest",  1f);
-            _gasPress   = PlayerPrefs.GetFloat("G923_GasPress", -1f);
-            _brakeRest  = PlayerPrefs.GetFloat("G923_BrakeRest",  1f);
-            _brakePress = PlayerPrefs.GetFloat("G923_BrakePress", -1f);
-            _clutchRest  = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_REST,  -1f);
-            _clutchPress = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_PRESS,  1f);
-
-            // v1.6.4: HORI Truck pedales (rz/slider/slider1) son hardware-fijos:
-            // rest=-1.0, press=+1.0 (LE16 byte 0x0000 → -1, 0xFFFF → +1). Discovery
-            // capturando esto a mano es frágil — si el operador tiene un pie en
-            // el pedal durante SnapshotPedalRests, la captura sale invertida o
-            // truncada (ej. rest=1, press=0 → freno pegado al 100% en runtime
-            // porque NormalizePedal(-1,1,0)=2→clamp01=1). Forzar los hardware
-            // constants here resuelve TODOS los modos de captura mala. Discovery
-            // sigue identificando QUÉ axis es brake vs clutch (eso varía); solo
-            // los valores rest/press son inmutables.
-            // G923 NO entra a este bloque — sus pedales tienen polaridad/scale
-            // distintas según variante PS/Xbox y deben respetar Discovery.
             if (IsHORITruck(device))
             {
-                if (Mathf.Abs(_brakeRest - (-1f)) > 0.01f || Mathf.Abs(_brakePress - 1f) > 0.01f)
-                {
-                    Debug.Log($"[UIInputNew] HORI Truck — forzando _brakeRest=-1, _brakePress=+1 (eran {_brakeRest:F3}/{_brakePress:F3})");
-                    _brakeRest = -1f; _brakePress = 1f;
-                    PlayerPrefs.SetFloat("G923_BrakeRest", -1f);
-                    PlayerPrefs.SetFloat("G923_BrakePress", 1f);
-                }
-                if (Mathf.Abs(_clutchRest - (-1f)) > 0.01f || Mathf.Abs(_clutchPress - 1f) > 0.01f)
-                {
-                    Debug.Log($"[UIInputNew] HORI Truck — forzando _clutchRest=-1, _clutchPress=+1 (eran {_clutchRest:F3}/{_clutchPress:F3})");
-                    _clutchRest = -1f; _clutchPress = 1f;
-                    PlayerPrefs.SetFloat(PREF_G923_CLUTCH_REST, -1f);
-                    PlayerPrefs.SetFloat(PREF_G923_CLUTCH_PRESS, 1f);
-                }
-                PlayerPrefs.Save();
+                // HORI Truck pedales (rz/slider/slider1): hardware-fijos a rest=-1, press=+1.
+                // HID LE16 byte 0x0000 → Unity normalized -1, 0xFFFF → +1. Discovery puede
+                // capturar valores mal si el operador tiene un pie en el pedal durante el
+                // snapshot — por eso NO leemos PlayerPrefs para rest/press de HORI, solo
+                // para el axis (qué axis es brake vs clutch sí varía por kiosko).
+                // Throttle bypassa NormalizePedal vía HoriThrottleReader (P/Invoke directo
+                // al HID byte 21-22), así que sus rest/press son cosméticos.
+                _gasRest = 0f; _gasPress = 1f;
+                _brakeRest = -1f; _brakePress = 1f;
+                _clutchRest = -1f; _clutchPress = 1f;
+                Debug.Log("[UIInputNew] HORI Truck pedales — rest=-1 press=+1 hardcoded (PlayerPrefs G923_*Rest/Press ignorados)");
+            }
+            else
+            {
+                // G923 y otros: cargar calibración del menú (Discovery por variante PS/Xbox).
+                _gasRest    = PlayerPrefs.GetFloat("G923_GasRest",  1f);
+                _gasPress   = PlayerPrefs.GetFloat("G923_GasPress", -1f);
+                _brakeRest  = PlayerPrefs.GetFloat("G923_BrakeRest",  1f);
+                _brakePress = PlayerPrefs.GetFloat("G923_BrakePress", -1f);
+                _clutchRest  = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_REST,  -1f);
+                _clutchPress = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_PRESS,  1f);
             }
 
             // Calibración del steering (si no existe, rango ideal -1..1 sin offset)

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -261,6 +261,15 @@ namespace Gley.UrbanSystem
         // pasa"), cancelar el sticky. -1 = no en estado stuck-indicator.
         // Reseteado en cada path donde _manualReverseLatched se limpia.
         private float _stuckIndicatorStartedAt = -1f;
+
+        // v1.6.7 (Fase B7): timer para debounce de Neutral transitorio reportado
+        // por HoriShifterReader cuando el lever cruza entre gates físicos
+        // (~50-200ms en N). Sin esto: desiredGear=0 → toNeutral=true →
+        // _currentGear=0 → bloqueado en N forever al llegar al siguiente gear
+        // sin clutch ("atorado a 20 km/h", reportado por Aramis 2026-05-11).
+        // -1f = no pending. Reseteado en AttachToWheelDevice y al volver a gear.
+        private float _horiNeutralPendingSince = -1f;
+
         private bool _lastTrianglePressed;
         private bool _lastRestartPressed;
         private float _menuComboTimer;
@@ -1338,6 +1347,7 @@ namespace Gley.UrbanSystem
             _manualReverseLatched = false;
             _lastCrossPressedManual = false;
             _stuckIndicatorStartedAt = -1f;
+            _horiNeutralPendingSince = -1f; // v1.6.7 (Fase B7) reset debounce
 
             // Si el device es Logitech/G923, sembrar los defaults faltantes
             // sin pisar lo que ya esté en PlayerPrefs (preserva remaps F8).
@@ -2033,6 +2043,43 @@ namespace Gley.UrbanSystem
                             }
                         }
                     }
+
+                    // v1.6.7 (Fase B7): HORI-only Neutral debounce. HoriShifterReader
+                    // reporta byte[1]=0 brevemente durante el cruce mecánico entre
+                    // gates físicos (~50-200ms). Sin debounce: desiredGear=0 →
+                    // toNeutral=true → _currentGear=0 → al llegar al siguiente gear
+                    // sin clutch, BLOQUEADO en N forever ("atorado a 20 km/h",
+                    // Aramis 2026-05-11).
+                    //
+                    // Solución: ignorar transitorios <NEUTRAL_HOLD_SECONDS. Permitir
+                    // Neutral real solo si el lever permanece en N por más tiempo
+                    // (operador deliberadamente disengage). Si llega gear válido
+                    // antes del threshold, saltamos el Neutral transitorio
+                    // manteniendo _currentGear hasta que se resuelva con clutch.
+                    //
+                    // Aplica solo a HORI (reader continuo). G923 pulse-based no
+                    // tiene este problema porque desiredGear=0 entre gears es
+                    // legítimo (no había pulse).
+                    const float NEUTRAL_HOLD_SECONDS = 0.30f;
+                    if (isHoriShift && desiredGear == 0 && _currentGear != 0)
+                    {
+                        if (_horiNeutralPendingSince < 0f)
+                            _horiNeutralPendingSince = Time.unscaledTime;
+                        if (Time.unscaledTime - _horiNeutralPendingSince < NEUTRAL_HOLD_SECONDS)
+                        {
+                            // Transitorio: enmascarar como sameGear (el apply logic
+                            // lo tratará como no-op, _currentGear no cambia).
+                            desiredGear = _currentGear;
+                        }
+                        // Si elapsed >= NEUTRAL_HOLD_SECONDS, dejar desiredGear=0
+                        // y propagar al apply normal (toNeutral=true → engage
+                        // Neutral intencional del operador).
+                    }
+                    else
+                    {
+                        _horiNeutralPendingSince = -1f;
+                    }
+
                     // Reversa por Bind_reverse: en G923 PS el R físico es button19
                     // (cubierto por el array hardcoded de _gearControls); en
                     // G923 Xbox es button12 (HOLD level-detectable mientras la

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -326,6 +326,14 @@ namespace Gley.UrbanSystem
         // sí al revés. HoriThrottleReader se registra aquí en su Bootstrap.
         // Devuelve el throttle 0..1 leído raw del HID byte 21-22.
         public static System.Func<float> HoriThrottleProvider;
+
+        // HoriShifterReader (v1.6.0): raw HID lever position, bypasses Unity's
+        // pulse-only button7. Returns: -1=R, 0=N, 1-6=gears, int.MinValue=not connected.
+        // Asignado por HoriShifterReader.Bootstrap. UIInputNew NO lo consume todavía
+        // — la integración runtime (replace _manualReverseLatched band-aid) está
+        // en stash@{0} (v1.6.2 reverted) y se aplicará en una rama futura. Esta
+        // declaración existe solo para que HoriShifterReader.cs compile.
+        public static System.Func<int> HoriShifterStateProvider;
         #endregion
         public const string PREF_BIND_DRIVE = "Bind_drive";
         public const string PREF_BIND_PADDLE_LEFT = "Bind_paddleLeft";

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -327,12 +327,23 @@ namespace Gley.UrbanSystem
         // Devuelve el throttle 0..1 leído raw del HID byte 21-22.
         public static System.Func<float> HoriThrottleProvider;
 
-        // HoriShifterReader (v1.6.0): raw HID lever position, bypasses Unity's
-        // pulse-only button7. Returns: -1=R, 0=N, 1-6=gears, int.MinValue=not connected.
-        // Asignado por HoriShifterReader.Bootstrap. UIInputNew NO lo consume todavía
-        // — la integración runtime (replace _manualReverseLatched band-aid) está
-        // en stash@{0} (v1.6.2 reverted) y se aplicará en una rama futura. Esta
-        // declaración existe solo para que HoriShifterReader.cs compile.
+        // HoriShifterReader (v1.6.0 plan, integrado en v1.6.6): raw HID lever
+        // position, bypasses Unity's PULSE-only button2..6 + button7. Returns:
+        // -1=R, 0=N, 1-6=gears, int.MinValue=not connected/uncalibrated.
+        //
+        // Asignado por HoriShifterReader.Bootstrap. UIInputNew lo consume en el
+        // bloque Manual de Update() para sobrescribir desiredGear cuando el
+        // device es HORI y el reader reporta valor válido (≠ int.MinValue).
+        // El loop pulse-based de _gearControls queda como fallback (G923, o
+        // HORI con reader dead/handle cerrado).
+        //
+        // Por qué este fix existe (bug v1.6.5 reportado por Aramis 2026-05-11):
+        // shifter:button3 (3ra) y arriba parecen ser PULSE en HPC-044U, no HOLD.
+        // Unity InputSystem ve el botón 1-2 frames y después desiredGear→0=Neutral
+        // → carro pierde tracción y coasts a 20-30 km/h hasta meter otra marcha.
+        // 1ra (shifter:trigger) y 2da (shifter:button2) parecen ser HOLD por
+        // diferencias del firmware HORI. Reader lee byte[1] bits 0-5 directo
+        // del HID, continuo y persistente.
         public static System.Func<int> HoriShifterStateProvider;
         #endregion
         public const string PREF_BIND_DRIVE = "Bind_drive";
@@ -1990,8 +2001,28 @@ namespace Gley.UrbanSystem
                 if (_hasWheel && _wheelDevice != null)
                 {
                     desiredGear = 0;
-                    if (_gearControls != null)
+
+                    // v1.6.6 (Fase B6): para HORI usamos HoriShifterReader que
+                    // lee byte[1] bits 0-5+6 directo del HID (persistente,
+                    // bypassa Unity PULSE-only). Bug v1.6.5: 3ra/4ta/5ta/6ta
+                    // perdían la marcha tras 1-2 frames porque button2..6 son
+                    // PULSE en HPC-044U y _gearControls los leía via IsPressed.
+                    // 1ra (trigger) y reverse (sticky latch v1.5.9) tenían
+                    // workarounds; el reader unifica todo.
+                    bool isHoriShift = _wheelDevice != null && IsHORITruck(_wheelDevice);
+                    int readerGear = (isHoriShift && HoriShifterStateProvider != null)
+                        ? HoriShifterStateProvider() : int.MinValue;
+                    if (isHoriShift && readerGear != int.MinValue)
                     {
+                        // Reader vivo. -1=R, 0=N, 1-6=gear. Asigna directo;
+                        // el sticky latch debajo queda dormant (gearActive=true
+                        // cancela el latch al detectar gear válido).
+                        desiredGear = readerGear;
+                    }
+                    else if (_gearControls != null)
+                    {
+                        // Fallback pulse-based: G923, o HORI con reader dead
+                        // (handle cerrado / device desconectado / uncalibrated).
                         for (int i = 0; i < _gearControls.Length; i++)
                         {
                             if (IsPressed(_gearControls[i]))

--- a/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
+++ b/2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs
@@ -1453,6 +1453,36 @@ namespace Gley.UrbanSystem
             _clutchRest  = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_REST,  -1f);
             _clutchPress = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_PRESS,  1f);
 
+            // v1.6.4: HORI Truck pedales (rz/slider/slider1) son hardware-fijos:
+            // rest=-1.0, press=+1.0 (LE16 byte 0x0000 → -1, 0xFFFF → +1). Discovery
+            // capturando esto a mano es frágil — si el operador tiene un pie en
+            // el pedal durante SnapshotPedalRests, la captura sale invertida o
+            // truncada (ej. rest=1, press=0 → freno pegado al 100% en runtime
+            // porque NormalizePedal(-1,1,0)=2→clamp01=1). Forzar los hardware
+            // constants here resuelve TODOS los modos de captura mala. Discovery
+            // sigue identificando QUÉ axis es brake vs clutch (eso varía); solo
+            // los valores rest/press son inmutables.
+            // G923 NO entra a este bloque — sus pedales tienen polaridad/scale
+            // distintas según variante PS/Xbox y deben respetar Discovery.
+            if (IsHORITruck(device))
+            {
+                if (Mathf.Abs(_brakeRest - (-1f)) > 0.01f || Mathf.Abs(_brakePress - 1f) > 0.01f)
+                {
+                    Debug.Log($"[UIInputNew] HORI Truck — forzando _brakeRest=-1, _brakePress=+1 (eran {_brakeRest:F3}/{_brakePress:F3})");
+                    _brakeRest = -1f; _brakePress = 1f;
+                    PlayerPrefs.SetFloat("G923_BrakeRest", -1f);
+                    PlayerPrefs.SetFloat("G923_BrakePress", 1f);
+                }
+                if (Mathf.Abs(_clutchRest - (-1f)) > 0.01f || Mathf.Abs(_clutchPress - 1f) > 0.01f)
+                {
+                    Debug.Log($"[UIInputNew] HORI Truck — forzando _clutchRest=-1, _clutchPress=+1 (eran {_clutchRest:F3}/{_clutchPress:F3})");
+                    _clutchRest = -1f; _clutchPress = 1f;
+                    PlayerPrefs.SetFloat(PREF_G923_CLUTCH_REST, -1f);
+                    PlayerPrefs.SetFloat(PREF_G923_CLUTCH_PRESS, 1f);
+                }
+                PlayerPrefs.Save();
+            }
+
             // Calibración del steering (si no existe, rango ideal -1..1 sin offset)
             _steerCenter = PlayerPrefs.GetFloat("G923_SteerCenter", 0f);
             _steerMax    = PlayerPrefs.GetFloat("G923_SteerMax",   1f);

--- a/2026MVP/Assets/Tests.meta
+++ b/2026MVP/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2eb973985155eef3224ea521c4cc1394
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Tests/EditMode.meta
+++ b/2026MVP/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8dab3a224c1d80100186e2d865419e91
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Tests/EditMode/InputMathTests.cs
+++ b/2026MVP/Assets/Tests/EditMode/InputMathTests.cs
@@ -1,0 +1,99 @@
+using NUnit.Framework;
+using TlaxSim.Input;
+
+namespace TlaxSim.Tests
+{
+    // Tests para InputMath.NormalizePedal — la función pura que normaliza un
+    // pedal raw a [0,1] usando rest/press calibrados.
+    //
+    // Lección 4 de HORI_CALIBRATION_LESSONS.md: tener este suite hubiera
+    // pillado el bug v1.6.3 (rest=1, press=0 corruptos → freno stuck en 1.0)
+    // sin necesidad de un kiosko para reproducir.
+    public class InputMathTests
+    {
+        const float EPS = 1e-4f;
+
+        [Test]
+        public void Standard_HalfPress_Returns05()
+        {
+            // Pedal estilo "0..1" (ej. HORI throttle via reader)
+            Assert.AreEqual(0.5f, InputMath.NormalizePedal(0.5f, 0f, 1f), EPS);
+        }
+
+        [Test]
+        public void Bipolar_Quarter_Returns025()
+        {
+            // Pedal -1..+1 (ej. HORI brake/clutch en rz/slider)
+            Assert.AreEqual(0.25f, InputMath.NormalizePedal(-0.5f, -1f, 1f), EPS);
+        }
+
+        [Test]
+        public void InvertedPolarity_G923PS_Center_Returns05()
+        {
+            // G923 PS gas: idle=1, press=-1 → en el medio (raw=0) debe dar 0.5
+            Assert.AreEqual(0.5f, InputMath.NormalizePedal(0f, 1f, -1f), EPS);
+        }
+
+        [Test]
+        public void DivByZeroGuard_RestEqualsPress_ReturnsZero()
+        {
+            // span=0 → return 0 (guard contra divide-by-zero / NaN)
+            Assert.AreEqual(0f, InputMath.NormalizePedal(0.5f, 0f, 0f), EPS);
+        }
+
+        [Test]
+        public void SpanExactly005_DoesNotTriggerGuard()
+        {
+            // El guard corta cuando |span| < 0.05f estrictamente, no <=.
+            // Span=0.05 exacto: 0.05 < 0.05 es false → NO retorna 0.
+            // Pasa al cálculo: (0.025 - 0) / 0.05 = 0.5
+            Assert.AreEqual(0.5f, InputMath.NormalizePedal(0.025f, 0f, 0.05f), EPS);
+        }
+
+        [Test]
+        public void SpanJustBelow005_ReturnsZero()
+        {
+            // span = 0.04999 → guard kicks in → 0
+            Assert.AreEqual(0f, InputMath.NormalizePedal(0.025f, 0f, 0.04999f), EPS);
+        }
+
+        [Test]
+        public void RawAboveRange_ClampsTo1()
+        {
+            // raw fuera de rango por arriba (operador apretó más de lo calibrado)
+            Assert.AreEqual(1f, InputMath.NormalizePedal(2f, 0f, 1f), EPS);
+        }
+
+        [Test]
+        public void RawBelowRange_ClampsTo0()
+        {
+            // raw fuera de rango por abajo (sensor emite negativo en rest)
+            Assert.AreEqual(0f, InputMath.NormalizePedal(-1f, 0f, 1f), EPS);
+        }
+
+        [Test]
+        public void V163RegressionBug_BrakeStuckPressed()
+        {
+            // Pasajeros 2 v1.6.3: PlayerPrefs corruptas dejaron
+            // G923_BrakeRest=1.0, G923_BrakePress=0.0 (polaridad invertida + range parcial).
+            // El raw idle del HORI brake (rz=−1) daba: (-1-1)/(0-1) = 2 → clamp01 = 1.0
+            // → freno stuck pisado al 100% siempre → carro no avanzaba ni en Auto.
+            // Este test atrapa la regresión si alguien rompe el clamp.
+            float actual = InputMath.NormalizePedal(-1f, 1f, 0f);
+            Assert.AreEqual(1f, actual, EPS,
+                "Polaridad invertida con rest=1 press=0 raw=-1 da clamp01=1.0 (bug v1.6.3)");
+        }
+
+        [Test]
+        public void HoriBrakeSano_RestNeg1_PressPos1()
+        {
+            // HORI brake calibración correcta (rest=-1, press=1):
+            // - idle (raw=-1) → 0
+            // - half (raw=0) → 0.5
+            // - full (raw=1) → 1
+            Assert.AreEqual(0f,   InputMath.NormalizePedal(-1f, -1f, 1f), EPS, "idle=0");
+            Assert.AreEqual(0.5f, InputMath.NormalizePedal( 0f, -1f, 1f), EPS, "half=0.5");
+            Assert.AreEqual(1f,   InputMath.NormalizePedal( 1f, -1f, 1f), EPS, "full=1");
+        }
+    }
+}

--- a/2026MVP/Assets/Tests/EditMode/InputMathTests.cs.meta
+++ b/2026MVP/Assets/Tests/EditMode/InputMathTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9d00feb65181102c460cebbe351ef54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/Assets/Tests/EditMode/TlaxSim.Tests.EditMode.asmdef
+++ b/2026MVP/Assets/Tests/EditMode/TlaxSim.Tests.EditMode.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "TlaxSim.Tests.EditMode",
+    "rootNamespace": "TlaxSim.Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "TlaxSim.Input"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/2026MVP/Assets/Tests/EditMode/TlaxSim.Tests.EditMode.asmdef.meta
+++ b/2026MVP/Assets/Tests/EditMode/TlaxSim.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 983fd1a094402670ba1861038cb3fc18
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/2026MVP/CLAUDE.md
+++ b/2026MVP/CLAUDE.md
@@ -497,7 +497,7 @@ Ver `PLAN_HORI_TRUCK.md` para documentacion completa.
 
 - **Plataforma:** Windows only (NO macOS)
 - **USB:** 2 devices separados — `HORI TRUCK CONTROL SYSTEM WHEEL` + `HORI TRUCK CONTROL SYSTEM SHIFTER`
-- **Deteccion:** `UIInputNew.IsHORITruck()` por displayName/product que contenga "HORI"
+- **Deteccion (v1.6.5+):** `UIInputNew.IsHORITruck()` matchea por VID + PID + interfaceName="HID" usando `HIDDeviceDescriptor.FromJson` (VID=0x0F0D + PID=0x017A wheel / 0x0186 shifter). Fallback a displayName/product.Contains("HORI") preserva v1.6.4.
 - **Defaults automaticos** en `AttachToWheelDevice()` al detectar HORI (no usa `EnsureG923PSDefaults`)
 
 ### Mapping verificado (F7, 2026-05-06)
@@ -537,6 +537,37 @@ Ver `PLAN_HORI_TRUCK.md` para documentacion completa.
 
 ### Pendiente
 - Verificar force feedback (HORI no tiene FFB — `LogitechFFB.cs` no-op)
+
+### v1.6.4 — pedales hardware-fijos (NO leer rest/press de PlayerPrefs)
+
+Tras 4 builds de debug (v1.6.1→v1.6.4) y 4h de root cause analysis (ver
+`HORI_CALIBRATION_LESSONS.md`), `UIInputNew.AttachToWheelDevice` hardcodea
+los rest/press de los pedales HORI cuando detecta el wheel:
+
+```csharp
+if (IsHORITruck(device)) {
+    _gasRest = 0f; _gasPress = 1f;        // Throttle: sentinel via reader
+    _brakeRest = -1f; _brakePress = 1f;   // rz HID byte 23-24 LE16 → -1..+1
+    _clutchRest = -1f; _clutchPress = 1f; // slider/slider1 HID byte 19-20
+}
+```
+
+Razón: Phase 4/6 Discovery captura los rest/press dinámicamente, pero si el
+operador tiene un pie en el pedal durante `SnapshotPedalRests`, captura
+`rest=+1` (pedal pisado) → `press = rest + delta = 0` → `NormalizePedal(raw=-1, 1, 0) = 1.0`
+→ **freno stuck pisado al 100% sin pedal físico** → carro inmóvil. Bug real
+en Pasajeros 2 documentado.
+
+### v1.6.5 — hardening adicional
+
+- **F7 muestra readers HORI** (`LogConsolePanel.cs`): nueva sección "CUSTOM HID READERS" lee `HoriThrottleReader.Instance.Value` y `HoriShifterReader.Instance` directo. Antes el throttle no aparecía en F7 porque Unity nunca crea `AxisControl` para el byte huérfano.
+- **`IsHandleOpen` en HoriThrottleReader**: nuevo getter expone si el handle HID está abierto. F7 imprime `handle=open|CLOSED`.
+- **VID/PID detection** en `IsHORITruck` (ver línea arriba).
+- **Phase 4/6 NO escribe `*Rest/Press` para HORI** + gates `pedalsCal`/`clutchPathPersisted` axis-only para HORI en `PrepareWheelScreen`. Combinado con v1.6.4 elimina contaminación del registry.
+- **Sanity check hardware-aware** (`SanityCheckThenLoad`): si HORI brake/clutch raw cae fuera de `[-1.05, +1.05]` durante 3 frames consecutivos → invalida solo el axis path para forzar re-Discovery dirigida.
+- **`SimulatorApiClient.BuildCalibrationPayload`** reporta canónico (-1/+1) al backend cuando detecta HORI sentinel.
+- **Phase 3 ya no auto-pasa para HORI** (Fase B5). Verifica en vivo que `HoriThrottleReader.Value > 0.7` con handle abierto antes de marcar throttleDone. Si el reader no inicializa tras 8s, prompt cambia a "HoriThrottleReader sin handle - verifica USB". Cierra el hueco silencioso de v1.5.12 donde un reader muerto pasaba de calibración a gameplay sin diagnóstico.
+- **`InputMath.NormalizePedal` extraído** a `Assets/Custom/InputMath/` con tests EditMode (10 casos) que cubren divide-by-zero, polaridad invertida, span boundary, y el regression test del bug v1.6.3.
 
 ## Build
 

--- a/2026MVP/CLAUDE.md
+++ b/2026MVP/CLAUDE.md
@@ -575,6 +575,14 @@ Bug Aramis 2026-05-11: 3ra/4ta/5ta/6ta intermitentes con HORI — el carro se qu
 
 Fix: `UIInputNew.cs:1989+` ahora consume `HoriShifterStateProvider` (asignado por `HoriShifterReader.Bootstrap`) cuando el device es HORI y el reader retorna valor válido (`≠ int.MinValue`). El reader lee `byte[1] bits 0-5+6` directo del HID — persistente mientras la palanca está en gear. Pulse-based queda como fallback si el reader muere.
 
+### v1.6.7 — Fase B7: Neutral debounce HORI (fix "atorado a 20 km/h")
+
+Bug introducido por la integración v1.6.6: el reader continuo expuso una trampa en la lógica de gear apply. `HoriShifterReader.byte[1]` reporta 0 brevemente durante el cruce mecánico entre gates (~50-200ms). `UIInputNew.cs` permite `toNeutral=true` (Neutral sin clutch) → `_currentGear=0` durante el transit → al llegar al siguiente gear, `clutchInput=0` lo bloquea forever → vehículo cae a `motorTorque=0`.
+
+Fix: `UIInputNew.cs:2046+` agrega debounce HORI-only de 300ms — si reader reporta 0 mientras `_currentGear≠0`, enmascarar `desiredGear` como sameGear hasta que el lever termine en gate o sostenga N >300ms. Preserva pedagogía: sin clutch → rechino + vehículo en 2da, no atorado.
+
+Ver `HORI_CALIBRATION_LESSONS.md` sección "v1.6.7 — Fase B7" para detalle completo, edge cases y limitaciones conocidas.
+
 ## Build
 
 - **Ejecutable:** `build/<version>/Tlax2026-RC.exe` (productName = `Tlax2026-RC`, NO `Tlax2026MVP`)

--- a/2026MVP/CLAUDE.md
+++ b/2026MVP/CLAUDE.md
@@ -569,6 +569,12 @@ en Pasajeros 2 documentado.
 - **Phase 3 ya no auto-pasa para HORI** (Fase B5). Verifica en vivo que `HoriThrottleReader.Value > 0.7` con handle abierto antes de marcar throttleDone. Si el reader no inicializa tras 8s, prompt cambia a "HoriThrottleReader sin handle - verifica USB". Cierra el hueco silencioso de v1.5.12 donde un reader muerto pasaba de calibración a gameplay sin diagnóstico.
 - **`InputMath.NormalizePedal` extraído** a `Assets/Custom/InputMath/` con tests EditMode (10 casos) que cubren divide-by-zero, polaridad invertida, span boundary, y el regression test del bug v1.6.3.
 
+### v1.6.6 — Fase B6: HoriShifterStateProvider integrado en desiredGear
+
+Bug Aramis 2026-05-11: 3ra/4ta/5ta/6ta intermitentes con HORI — el carro se quedaba "clavado a 20-30 km/h" sin avanzar tras 2da. Causa: `shifter:button2..6` son PULSE 1-2 frames en HPC-044U (no HOLD como `shifter:trigger`), `_gearControls[i].IsPressed()` los perdía y `desiredGear→0=Neutral`.
+
+Fix: `UIInputNew.cs:1989+` ahora consume `HoriShifterStateProvider` (asignado por `HoriShifterReader.Bootstrap`) cuando el device es HORI y el reader retorna valor válido (`≠ int.MinValue`). El reader lee `byte[1] bits 0-5+6` directo del HID — persistente mientras la palanca está en gear. Pulse-based queda como fallback si el reader muere.
+
 ## Build
 
 - **Ejecutable:** `build/<version>/Tlax2026-RC.exe` (productName = `Tlax2026-RC`, NO `Tlax2026MVP`)

--- a/2026MVP/HORI_CALIBRATION_LESSONS.md
+++ b/2026MVP/HORI_CALIBRATION_LESSONS.md
@@ -476,6 +476,78 @@ está calibrado. Esto:
 
 Ver plan completo en `/Users/sim4r4/.claude/plans/necesito-de-todo-tu-woolly-lightning.md`.
 
+## v1.6.6 — Fase B6: bug 3ª gear PULSE intermitente
+
+**Reportado por Aramis 2026-05-11**: tras OTA exitoso a v1.6.5, el operador en
+HORI metía 1ra → bien, 2da → bien, 3ra → a veces funciona, a veces se queda
+"clavado a 20-30 km/h" sin avanzar.
+
+### Causa raíz
+
+`UIInputNew.cs:336` declaraba `HoriShifterStateProvider` para futura integración
+runtime (v1.6.0 plan), con comentario literal en el código:
+
+> "Asignado por HoriShifterReader.Bootstrap. UIInputNew NO lo consume todavía"
+
+Por tanto la lógica de gear en `Update()` (línea 1995-2003) seguía iterando
+sobre `_gearControls[i].IsPressed(...)` via Unity InputSystem. En HPC-044U:
+- `shifter:trigger` (1ra) — HOLD (persistente mientras lever en gear)
+- `shifter:button2` (2da) — HOLD aparentemente
+- `shifter:button3..6` (3ra-6ta) — **PULSE** 1-2 frames al cruzar la posición
+- `shifter:button7` (R) — PULSE (ya conocido v1.5.8+)
+
+Para 3ra: Unity ve `button3` presionado 1-2 frames → `desiredGear=3` → en el
+siguiente frame `IsPressed(button3)=false` → for-loop encuentra ningún
+gear pressed → `desiredGear=0=Neutral` → vehículo en Neutral pierde tracción
+del motor → coasts a la velocidad que tenía (~20-30 km/h después de 2da).
+
+**Intermitencia explicada**: si el operador presiona button3 y otro frame
+Unity tiene encolado el event → puede tomarse hasta 2-3 frames detectarlo
+→ a veces el polling de gear lo agarra "dentro" del pulse, a veces "después".
+
+### Fix v1.6.6
+
+Conectar `HoriShifterStateProvider` al cálculo de `desiredGear`. El reader
+ya lee `byte[1] bits 0-5+6` directo del HID con calibración HPC-044U
+hardcoded por default (ver `HoriShifterReader.ApplyHPC044UDefaults`), retorna
+`-1=R, 0=N, 1-6=gear, int.MinValue=not connected`.
+
+`UIInputNew.cs` (Update Manual block):
+
+```csharp
+bool isHoriShift = _wheelDevice != null && IsHORITruck(_wheelDevice);
+int readerGear = (isHoriShift && HoriShifterStateProvider != null)
+    ? HoriShifterStateProvider() : int.MinValue;
+if (isHoriShift && readerGear != int.MinValue)
+{
+    desiredGear = readerGear;  // reader vivo: directo
+}
+else if (_gearControls != null)
+{
+    // fallback pulse-based (G923, o HORI con reader dead)
+    for (int i = 0; i < _gearControls.Length; i++) { ... }
+}
+```
+
+### Defensivo
+
+- Si `HoriShifterReader` no inicializó (USB hot-plug, handle CLOSED,
+  uncalibrated), `HoriShifterStateProvider()` retorna `int.MinValue`
+  → cae al pulse-based legacy. Comportamiento igual a v1.6.5.
+- El sticky latch v1.5.9 de reverse (`_manualReverseLatched`) queda dormant
+  cuando reader está vivo (gearActive=true cancela el latch al detectar
+  gear válido). NO se removió por seguridad — sigue siendo fallback si el
+  reader muere mid-gameplay.
+- G923 y Moto NO cambian — `isHoriShift` gatea todo el cambio.
+
+### Validación
+
+Aramis tiene HoriShifterReader vivo en v1.6.5 (logs confirmaron
+`Started poller on \\?\hid#vid_0f0d&pid_0186&col01...`). En v1.6.6
+después del deploy, meter 3ra debe quedar engranada **persistente**.
+Confirmar con F7 sostén 1.5s — `HoriShifterReader gear=3 conn=True`
+mientras la palanca esté en posición.
+
 ## Archivos tocados en v1.6.4
 
 - `2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs:1448-1471`

--- a/2026MVP/HORI_CALIBRATION_LESSONS.md
+++ b/2026MVP/HORI_CALIBRATION_LESSONS.md
@@ -262,17 +262,137 @@ S3 vía portal admin.
 - [ ] **Eliminar `_h<hash>` sufijo dependence**: si Unity bumps a una versión
   con CRC32 diferente, los hashes existentes se vuelven huérfanos. Actualmente
   no es problema pero sí frágil.
-- [ ] **Detección HORI por VID/PID en lugar de displayName**: ver lección 11.
-- [ ] **Discovery solo identifica axis para HORI**: actualmente Phase 4 brake
-  guarda axis + rest/press. Para HORI, los rest/press son ignorados. Limpiar
-  el código para que Phase 4/6 no escriba rest/press cuando IsHORITruck.
-- [ ] **Sanity check más inteligente**: en lugar de "si delta > 0.5 invalidar",
-  validar contra los rangos hardware esperados. Si HORI brake espera -1..+1,
-  pero el axis reporta 0..255 raw, esa es la señal real de "axis incorrecto"
-  vs "operator tocó el pedal".
-- [ ] **Test unitario de `NormalizePedal` con casos extremos**: divide-by-zero,
-  span negativo, raw fuera de [rest, press], inversión de polaridad. Hubiera
-  pillado el bug original sin necesidad de un kiosko.
+- [x] **Detección HORI por VID/PID en lugar de displayName** — resuelto en
+  v1.6.5 (Fase B1). `IsHORITruck` usa `HIDDeviceDescriptor.FromJson` con
+  match exacto VID=0x0F0D + PID=0x017A (wheel) o 0x0186 (shifter). Fallback
+  a strings preserva v1.6.4.
+- [x] **Discovery solo identifica axis para HORI** — resuelto en v1.6.5
+  (Fase B2). Phase 4 (brake) y Phase 6 (clutch) checan `IsHORITruck(dev)`
+  antes de escribir `G923_*Rest/Press`. Gates `pedalsCal` y `clutchPathPersisted`
+  en `PrepareWheelScreen` hacen requirement axis-only para HORI. Sin ese
+  ajuste de gates, fast-path se rompe (HORI re-Discovery cada boot).
+- [x] **Sanity check más inteligente** — resuelto en v1.6.5 (Fase B3).
+  `SanityCheckThenLoad` valida que axis raw HORI brake/clutch caiga en
+  `[-1.05, +1.05]` durante 3 frames consecutivos. Fuera de rango → invalida
+  SOLO el path para forzar Phase 4/6 dirigida (no wipe global). Window 3
+  frames evita falsos positivos por jitter post-attach.
+- [x] **Test unitario de `NormalizePedal`** — resuelto en v1.6.5 (Fase B4).
+  Función pura extraída a `Assets/Custom/InputMath/InputMath.cs` con asmdef
+  propio (`TlaxSim.Input`). UIInputNew delega via static `Func<>`, default
+  inline preserva runtime si la inyección no corre. 10 tests EditMode
+  cubren divide-by-zero, span boundary, polaridad invertida, rangos
+  out-of-calibración, y el regression test del bug v1.6.3.
+
+## v1.6.5 — Fase B5: verificación de throttle en Pantalla 2
+
+Hueco real detectado tras v1.6.4: si `HoriThrottleReader` falla al inicializar
+(USB hot-plug, driver conflict, otra app reservó el handle), v1.5.12 auto-pasaba
+la Phase 3 de Pantalla 2 sin verificación → operador llegaba a la escena con
+throttle muerto **silentemente**, sin manera de detectarlo en la calibración.
+
+### Cambio
+
+`MenuScreenManager.cs` Phase 3, branch HORI:
+
+```csharp
+if (devForGas != null && UIInputNew.IsHORITruck(devForGas))
+{
+    if (_horiPhase3StartTime < 0f) _horiPhase3StartTime = Time.unscaledTime;
+    float horiPhase3Elapsed = Time.unscaledTime - _horiPhase3StartTime;
+
+    var thrReader = HoriThrottleReader.Instance;
+    float thrValue = thrReader != null ? thrReader.Value : 0f;
+    bool thrHandleOpen = thrReader != null && thrReader.IsHandleOpen;
+
+    // Progress bar en vivo basada en valor del reader (no candidates discovery).
+    // Progresa visualmente igual que G923 — operador ve que algo está pasando.
+    float gasProgress = Mathf.Clamp01(thrValue);
+    if (Mathf.Abs(gasProgress - gasFillRT.anchorMax.x) > 0.005f) {
+        gasFillRT.anchorMax = new Vector2(gasProgress, 1);
+        gasFill.color = Color.Lerp(MenuTheme.SecondaryCrimson, MenuTheme.IndicatorDone, gasProgress);
+    }
+
+    const float HORI_THROTTLE_VERIFY_THRESHOLD = 0.7f;
+    const float HORI_READER_GRACE_SECONDS = 8f;
+
+    if (thrHandleOpen && thrValue >= HORI_THROTTLE_VERIFY_THRESHOLD)
+    {
+        // Pasa: handle abierto + valor superó threshold → la cadena P/Invoke
+        // (CreateFile → ReadFile → byte 21-22 LE16) funciona end-to-end.
+        throttleDone = true;
+        // ... (escribe sentinel + rest=0 + press=1 a PlayerPrefs)
+    }
+
+    if (!thrHandleOpen && horiPhase3Elapsed > HORI_READER_GRACE_SECONDS) {
+        wheelPrompt.text = "HoriThrottleReader sin handle - verifica USB del HORI Truck";
+        // No bloqueamos — el reader sigue intentando reabrir cada 2s
+        // (HoriThrottleReader.Update retry loop), conectar USB recupera.
+    }
+    return;
+}
+```
+
+### Soporte: `HoriThrottleReader.IsHandleOpen`
+
+Nuevo getter público en `HoriThrottleReader.cs`:
+
+```csharp
+public bool IsHandleOpen => _running && _hidHandle != null && !_hidHandle.IsInvalid;
+```
+
+Permite distinguir "reader vivo y leyendo" vs "reader muerto, retry loop
+intentando". El F7 LogConsolePanel también imprime `handle=open|CLOSED` en la
+sección "CUSTOM HID READERS" (Fase A) para diagnóstico paralelo sin entrar a
+Pantalla 2.
+
+### Comportamiento esperado
+
+| Estado | Pantalla 2 |
+|---|---|
+| HORI conectado, reader handle abierto, no se pisa pedal | "Pisa el ACELERADOR a fondo", barra al 0% |
+| HORI conectado, reader handle abierto, operador pisa | Barra crece hasta 100%, marca Phase 3 done al ≥0.7 |
+| HORI conectado pero reader nunca abrió (USB unplug) | Tras 8s: prompt cambia a "HoriThrottleReader sin handle - verifica USB del HORI Truck". Sigue chequeando — al reconectar, retry loop del reader recupera y la fase pasa al pisar |
+| Cambio de HORI a G923 a mid-flow | Reset del timer (`_horiPhase3StartTime=-1f`), discovery normal G923 corre |
+
+### Por qué 0.7 (no 0.85)
+
+`PEDAL_DELTA_THRESHOLD` para discovery via `SamplePedalCandidates` es 0.85 (delta
+máximo durante una ventana). Para verificación con reader directo (sin captura
+de baseline), usamos un umbral más bajo (0.7) porque:
+
+- El reader retorna 0..1 normalizado, no un delta vs baseline
+- 0.7 ≈ 70% pisado: lo suficientemente alto para no disparar con jitter,
+  lo suficientemente bajo para que el operador no tenga que poner el pedal
+  a fondo total
+
+### Por qué grace 8s (no 2s o 30s)
+
+`HoriThrottleReader.Update` reintenta abrir el handle cada 2s post-bootstrap
+(USB hot-plug). 8s = 4 intentos: cubre casos comunes (driver loading lento,
+USB enumerando) sin ser tan corto que falle por jitter de inicialización.
+
+Codex review v3 sugirió 6-8s; elegí 8s por margen.
+
+## Lecciones operativas adicionales (v1.6.5)
+
+### 16. Auto-pass silencioso esconde fallos de inicialización
+
+El auto-pass de v1.5.12 era una decisión defensiva ("si el operador no puede
+verificar el throttle en Unity, no le pidamos hacerlo"), pero el efecto neto
+era ocultar fallos del reader. La verificación con `IsHandleOpen + Value > 0.7`
+saca esos fallos a la luz **antes** de la escena, donde el operador puede
+actuar (verificar USB, F8 recalibrar).
+
+**Regla general:** validar antes en lugar de degradar silenciosamente. Un
+operador frustrado en Pantalla 2 es mejor que un operador frustrado en gameplay.
+
+### 17. F7 + Pantalla 2 son canales paralelos de diagnóstico
+
+F7 (Fase A) muestra `HoriThrottleReader v=X.XXX handle=open|CLOSED` durante
+TODO el ciclo de vida del juego — útil después de la calibración, en gameplay
+o post-mortem. Pantalla 2 (Fase B5) verifica EN VIVO antes de avanzar a la
+escena. Los dos paths se complementan: si F7 muestra `handle=CLOSED` después
+de gameplay, hubo un disconnect mid-examen.
 
 ## Archivos tocados en v1.6.4
 

--- a/2026MVP/HORI_CALIBRATION_LESSONS.md
+++ b/2026MVP/HORI_CALIBRATION_LESSONS.md
@@ -394,6 +394,88 @@ o post-mortem. Pantalla 2 (Fase B5) verifica EN VIVO antes de avanzar a la
 escena. Los dos paths se complementan: si F7 muestra `handle=CLOSED` después
 de gameplay, hubo un disconnect mid-examen.
 
+## Estado actual tras v1.6.5
+
+| Pieza | Estado |
+|---|---|
+| HORI throttle visible en F7 | ✅ Fase A — sección "CUSTOM HID READERS" |
+| HORI throttle visible en gameplay | ✅ HoriThrottleReader P/Invoke (v1.5.x+) |
+| HORI throttle verificado antes de gameplay | ✅ Fase B5 — Phase 3 valida `IsHandleOpen + Value≥0.7` |
+| HORI pedales hardware-fijos (rest/press) | ✅ v1.6.4 hardcodea, v1.6.5 deja de escribir basura del Discovery |
+| HORI brake/clutch path detection | ✅ Phase 4/6 Discovery + sanity hardware-aware (Fase B3) |
+| G923 sin cambios | ✅ todas las modificaciones gateadas por `IsHORITruck` |
+| Moto sin cambios | ✅ AttachAsMotoSimulator branch intacta |
+| Calibración persistente entre sesiones | ⚠️ **persiste, pero se re-valida cada arranque** en Pantalla 2 |
+| Recalibración silenciosa por sanity check destructivo | ✅ v1.5.12+ fix; v1.6.5 hardware-aware no toca rest/press HORI |
+
+## v1.7.0 — la cosa más importante que viene (calibración immutable + Pantalla 2 muerta)
+
+**Diagnóstico del usuario (2026-05-11)**: *"la pantalla donde se visualizan los
+sliders no es realmente necesaria. O se reconocen todos los controles para lo
+que se escogió y se carga la escena, o en caso de que algo no se reconozca,
+se debe de poner 'necesita calibración'."*
+
+Hoy Pantalla 2 hace DOS cosas mezcladas:
+1. **Calibración**: descubre paths de axes y los persiste en PlayerPrefs.
+2. **Verificación**: chequea que los controles respondan antes de cargar
+   la escena (Fase B5 v1.6.5 añadió esto para HORI throttle).
+
+Cada arranque corre ambas, mostrando los sliders incluso cuando todo ya
+está calibrado. Esto:
+- Confunde al operador con UI innecesaria
+- Re-corre Discovery cuando algo está "calibrado pero no perfecto" (ej. fingerprint match parcial)
+- Permite que un splash destructivo wipe-ee la calibración válida (caso v1.5.10 sanity check)
+
+### Visión v1.7.0
+
+**Separar definitivamente** calibración de verificación:
+
+1. **Calibración** se hace UNA SOLA VEZ por kiosko, en una **ventana dedicada
+   F8/F9** (sostén 1.5s). Operador. No usuario. Escribe a un archivo immutable:
+   ```
+   <persistentDataPath>/control_mapping.json
+   ```
+   con el mapping completo (axes paths + canónicos + bindings + tuning).
+   Read-only en runtime; nadie escribe excepto F8 explícito.
+
+2. **Verificación al arranque** (donde hoy vive Pantalla 2):
+   - Lee `control_mapping.json` y resuelve cada control en el device actual.
+   - Si TODOS responden a su prompt esperado → carga escena. **Sin UI de sliders.**
+   - Si ALGUNO no responde → modal *"Control X no responde, F8 sostén 1.5s para recalibrar (operador)."*
+   - Verificación semántica por control (codex review v3): pedir "Pisa el FRENO" y validar SOLO que la lectura del brake mapping suba >0.7, no que "algo se movió" genérico.
+
+3. **Migración v1.6.x → v1.7.0** atómica (codex review v3):
+   - Boot detecta JSON ausente + `Cal_DeviceFingerprint` en PlayerPrefs → migra a JSON.
+   - Detección canon-aware: para HORI, si `BrakeAxis="z"` (canon es `rz`) → flag `unverified=["brake"]`. No esperar al splash a descubrirlo.
+   - Write atómico: `.tmp` → fsync → rename + flag `Mig_v17_Done=1`.
+
+4. **Profiles como spec providers** (codex review v3): los profiles `G923PsProfile`, `G923XboxProfile`, `HoriTruckProfile`, `MotoProfile` aíslan canonicals/detección. **NO ejecutan el runtime** — `UIInputNew` sigue siendo host (no refactor de runtime mientras G923/Moto funcionen perfectamente).
+
+5. **Path degradado sin F8 obligatorio post-OTA**: para G923/Moto/HORI-Auto se genera JSON con defaults canónicos sin marcar nada → no exige F8 al primer arranque post-v1.7.0. Solo HORI-Manual sin clutch viable exige F8.
+
+### Por qué v1.7.0 mata la clase completa de bug
+
+| Bug pasado | Por qué no puede volver en v1.7.0 |
+|---|---|
+| `BrakeAxis="z"` heredado de G923 Xbox sembrado en HORI | Profile fija canónicos al instalar JSON; nadie sobrescribe en runtime |
+| `BrakeRest=1, BrakePress=0` capturados con pedal pisado | Calibración explícita F8 (no automática silenciosa), prompts claros + verificación inmediata |
+| Sanity check destructivo wipea calibración válida | Splash solo VERIFICA — no escribe a JSON jamás |
+| Auto-pass HORI con throttle reader muerto | Verificación semántica por control (B5 ya prefigura esto, v1.7.0 lo generaliza) |
+| Discovery captura el "pedal equivocado" cuando el operador pisa otro | UI deja de pedir Discovery; el JSON tiene los paths canónicos |
+
+### Pasos concretos para v1.7.0 (próximo sprint, 2-3 días)
+
+- `Assets/Custom/Input/ControlMapping.cs` — clase de datos JSON + load/save atómico
+- `Assets/Custom/Input/Profiles/{IDeviceProfile, G923Ps, G923Xbox, HoriTruck, Moto, Unknown}.cs` — spec providers
+- `Assets/Custom/CalibrationPanel.cs` — reemplaza/extiende F8 con flujo paso-a-paso para escribir JSON
+- `MenuScreenManager.cs` — Pantalla 2 reescrita a "verify-only" o eliminada (cargar escena directo si JSON válido)
+- `UIInputNew.cs` — leer de `ControlMapping.Active` en lugar de PlayerPrefs (~68 reads identificados)
+- Migración: detectar PlayerPrefs existente → migrar → marcar `unverified`/`needsRecalibrate` con canon-aware
+- Tests EditMode para ControlMapping (load/save round-trip, migración, schema validation)
+- Regression tests en sedan + motocicleta antes de merge (verificar input idéntico bit-a-bit)
+
+Ver plan completo en `/Users/sim4r4/.claude/plans/necesito-de-todo-tu-woolly-lightning.md`.
+
 ## Archivos tocados en v1.6.4
 
 - `2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs:1448-1471`

--- a/2026MVP/HORI_CALIBRATION_LESSONS.md
+++ b/2026MVP/HORI_CALIBRATION_LESSONS.md
@@ -548,6 +548,100 @@ después del deploy, meter 3ra debe quedar engranada **persistente**.
 Confirmar con F7 sostén 1.5s — `HoriShifterReader gear=3 conn=True`
 mientras la palanca esté en posición.
 
+## v1.6.7 — Fase B7: Neutral debounce HORI (bug "atorado a 20 km/h")
+
+**Reportado por Aramis 2026-05-11 post-deploy v1.6.6**: operador HORI en
+Manual va 40 km/h en 2da, mueve lever a 3ra, velocidad baja a 20 km/h
+y se atora. v1.6.6 (Fase B6) acababa de conectar HoriShifterStateProvider
+al cálculo de desiredGear.
+
+### Causa raíz
+
+`HoriShifterReader` reporta `byte[1]=0` brevemente durante el cruce
+mecánico del lever entre gates (~50-200ms). Sin debounce:
+
+1. Op en 2da, `_currentGear=2`, `desiredGear=2`. Estable.
+2. Op mueve lever sin clutch. Reader transitoriamente reporta 0.
+3. `desiredGear=0`. **Línea 2142**: `toNeutral=true` → condición
+   `clutchPressed || toNeutral || sameGear` se cumple → `_currentGear=0`.
+4. Lever termina en 3ra. Reader reporta 3. `desiredGear=3`.
+5. `clutchInput=0`, ni `toNeutral` ni `sameGear` → BLOQUEADO forever.
+6. `_currentGear=0` → `PlayerCar` aplica `motorTorque=0` → coast a 20 km/h.
+
+Antes de v1.6.6 (pulse-based gear detection), el bug existía latente:
+`_currentGear` se quedaba en última marcha conocida (2) y el vehículo
+bajaba un poco por rev-limit, pero NO caía a 0. El reader continuo del
+v1.6.6 expuso la trampa.
+
+### Fix v1.6.7
+
+**Suprimir transitorios Neutral del reader durante cruces de gate.**
+Solo aplicar Neutral si el lever sostiene la posición por
+>NEUTRAL_HOLD_SECONDS (300ms).
+
+`Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs` después del
+asignamiento `desiredGear = readerGear`:
+
+```csharp
+const float NEUTRAL_HOLD_SECONDS = 0.30f;
+if (isHoriShift && desiredGear == 0 && _currentGear != 0)
+{
+    if (_horiNeutralPendingSince < 0f)
+        _horiNeutralPendingSince = Time.unscaledTime;
+    if (Time.unscaledTime - _horiNeutralPendingSince < NEUTRAL_HOLD_SECONDS)
+    {
+        // Transitorio: enmascarar como sameGear → no-op en apply logic
+        desiredGear = _currentGear;
+    }
+    // elapsed >= threshold → dejar desiredGear=0 (Neutral intencional)
+}
+else
+{
+    _horiNeutralPendingSince = -1f;
+}
+```
+
+Reset defensivo en `AttachToWheelDevice` junto a `_manualReverseLatched=false`.
+
+### Por qué preserva la pedagogía
+
+Cuando el operador mueve lever sin clutch:
+- v1.6.7: debounce mantiene `_currentGear=2` durante el cruce; al llegar
+  a 3ra sin clutch → BLOQUEADO con rechino (`_pendingGearShiftWithoutClutchCount++`
+  línea 2176-2186). Vehículo sigue en 2da, rev-limit pero NO se atora.
+- ViolationDetector consume el contador: -5 pts + audio rechino.
+- Op escucha rechino, entiende: "necesito clutch". Lección preservada.
+
+Cuando el operador mueve lever CON clutch:
+- Reader reporta 0 transitorio brevemente (debounce activo).
+- `clutchInput>0.65` → `clutchPressed=true`.
+- Al llegar a 3ra: `desiredGear=3`, condición se cumple por `clutchPressed`
+  → `_currentGear=3`. Cambio limpio.
+
+Cuando el operador deliberadamente quiere Neutral:
+- Mueve lever a posición Neutral del gate y lo deja.
+- Tras 300ms, debounce expira → `desiredGear=0` propaga → `toNeutral=true`
+  → `_currentGear=0`. Comportamiento correcto.
+
+### Edge cases verificados
+
+- 2→3 con clutch: ✓ (transitorio enmascarado, cambio limpio al llegar)
+- 2→3 sin clutch: ✓ (rechino, vehículo en 2da, no atorado)
+- 2→N intencional (>300ms): ✓ (debounce expira, Neutral aplica)
+- N→1 con clutch: ✓ (`_currentGear==0` → condición debounce no aplica)
+- Hot-plug shifter: ✓ (AttachToWheelDevice resetea el field)
+- HORI → G923 switch: ✓ (`isHoriShift=false` → toda la rama no aplica)
+
+### Limitaciones conocidas (codex review v5)
+
+- **D↔R direct detection (`ViolationDetector.cs:195`) ahora más fácil de
+  enmascarar**: el paso por Neutral (debounce activo) lo oculta. Sigue
+  siendo bug pre-existente, no introducido por v1.6.7. Pendiente revisar
+  post-fix.
+- **300ms es arbitrario**: balance permitir disengage rápido vs enmascarar
+  tránsitos largos. Si hardware varía mucho entre kioskos, ajustar via
+  PlayerPref futuro.
+
 ## Archivos tocados en v1.6.4
 
 - `2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs:1448-1471`

--- a/2026MVP/HORI_CALIBRATION_LESSONS.md
+++ b/2026MVP/HORI_CALIBRATION_LESSONS.md
@@ -1,0 +1,293 @@
+# HORI Truck Calibration — Lecciones aprendidas (sesión 2026-05-08)
+
+Esfuerzo de 4 horas, 4 builds (v1.6.1 → v1.6.4), 2 kioskos (Pasajeros 1 + 2),
+3 enfoques (whitelist, migración, hardcode constants). El bug de "carro no
+avanza ni en Auto ni Manual" tuvo varias capas. Documentando todo aquí para
+que la siguiente sesión no repita los mismos errores.
+
+## Síntoma original
+
+Operador: *"Pasajeros 2 no funciona el automático. No acelera ni reversa."*
+HUD: 0 km/h con gear=1 visible (controles llegan al motor pero el carro no
+se mueve). Confirmado en Auto y Manual.
+
+## Causa raíz final (después de 3 hipótesis fallidas)
+
+`UIInputNew.NormalizePedal(raw, rest, press)` aplicado al freno con valores
+corruptos en PlayerPrefs:
+
+```csharp
+private float NormalizePedal(float raw, float rest, float press) {
+    float span = press - rest;
+    if (Mathf.Abs(span) < 0.05f) return 0f;        // guard de divide-por-cero
+    return Mathf.Clamp01((raw - rest) / span);
+}
+```
+
+Pasajeros 2 tenía persistido en `HKCU\Software\Tlaxcala\Tlax2026-RC`:
+- `G923_BrakeAxis = "rz"` ✓ (axis correcto del HORI)
+- `G923_BrakeRest = 1.0` ❌ (HORI sano sería -1.0)
+- `G923_BrakePress = 0.0` ❌ (HORI sano sería +1.0)
+
+Con esos valores: `NormalizePedal(raw=-1, 1.0, 0.0) = (-1-1)/(0-1) = 2 → clamp01 = 1.0`.
+**El freno reportaba 100% pisado siempre, sin importar la posición física del pedal.**
+En Auto: brake=1.0 cancela throttle → carro inmóvil. En Manual: igual + sin clutch
+threshold.
+
+## Por qué los rest/press se corrompieron
+
+HORI Truck pedales son hardware-fijos (HID LE16 0x0000..0xFFFF → Unity normalized
+-1..+1) per `CLAUDE.md`. El valor correcto siempre es `rest=-1, press=+1`. Pero
+`MenuScreenManager.cs` Phase 4 (brake Discovery) los CAPTURA dinámicamente cuando
+el operador pisa el freno:
+
+```csharp
+// MenuScreenManager.cs:2489-2499 (Phase 4 brake)
+float rest = pedalCandidateRests[bestIdx];                   // valor en SnapshotPedalRests
+float press = rest + pedalCandidateMaxDeltas[bestIdx];       // delta máximo durante press window
+PlayerPrefs.SetFloat("G923_BrakeRest", rest);
+PlayerPrefs.SetFloat("G923_BrakePress", press);
+```
+
+**Problema fundamental:** si el operador tiene un pie apoyado en el pedal durante
+`SnapshotPedalRests` ("suelta los pedales"), el snapshot captura `rest = +1.0`
+(pedal pisado, no la posición física de reposo). Cuando suelta, el delta es
+negativo, queda `press = 0.0`. Resultado: calibración guardada con polaridad
+invertida y rango parcial.
+
+## Las 3 hipótesis que NO resolvieron
+
+### Hipótesis 1 (v1.6.2): "Discovery elige axis fantasma"
+
+**Plan:** whitelist HORI a `rz/slider/slider1` en `CachePedalCandidates` para que
+ruido HID en axes no-pedal (`z`, `stick/y`, etc.) no gane el max-delta.
+
+**Por qué falló:** el axis SÍ era correcto (`rz`). El bug estaba en los valores
+rest/press, no en el axis path. Whitelist no toca rest/press.
+
+### Hipótesis 2 (v1.6.3): "Calibración corrupta persiste, hay que invalidar"
+
+**Plan:** detectar en `PrepareWheelScreen` si `|press - rest| < 1.5` (HORI sano
+es ≈2.0) y borrar las prefs para forzar re-Discovery con whitelist v1.6.2.
+
+**Por qué falló:** la migración SÍ disparaba (`Discovery limitada a rz,slider,slider1`
+aparecía en log post-OTA), borraba las prefs, Pantalla 2 entraba en Discovery,
+operador pisaba… y Discovery capturaba **otra vez** con el mismo bug (foot
+position issue). Ciclo infinito de invalidación → captura mala → invalidación.
+
+### Hipótesis 3 (write directo al registry vía SSH)
+
+**Plan:** matar el juego, `reg add /v G923_BrakeRest /t REG_DWORD /d 0xBF800000`
+para escribir -1.0/+1.0 directo, ignorar Discovery por completo.
+
+**Por qué falló:** al boot, Unity carga las prefs (-1/+1) ✓, pero el sanity
+check de v1.5.12 (líneas 3380-3424) compara el reading actual del axis vs el
+rest guardado. Si delta > 0.5 tras 1 retry, **DELETE de las prefs** (lines
+3411-3414) y re-Pantalla 2 → Discovery → captura mala. Mismo ciclo.
+
+## Solución final (v1.6.4)
+
+**HORI pedales son hardware-fijos. No leer ni escribir PlayerPrefs `*Rest/*Press`
+para HORI; usar constantes en código.**
+
+### Cambio 1 — `UIInputNew.AttachToWheelDevice` líneas 1448-1471
+
+```csharp
+if (IsHORITruck(device)) {
+    // HORI Truck pedales: hardware-fijos a rest=-1, press=+1.
+    // No leer PlayerPrefs G923_*Rest/Press (puede tener basura de Discovery
+    // mal capturado). Throttle bypassa via HoriThrottleReader (HID byte 21-22).
+    _gasRest = 0f; _gasPress = 1f;
+    _brakeRest = -1f; _brakePress = 1f;
+    _clutchRest = -1f; _clutchPress = 1f;
+} else {
+    // G923 / otros: cargar de PlayerPrefs (variantes PS/Xbox tienen polaridades
+    // distintas y SÍ deben respetar Discovery).
+    _gasRest    = PlayerPrefs.GetFloat("G923_GasRest",  1f);
+    _gasPress   = PlayerPrefs.GetFloat("G923_GasPress", -1f);
+    _brakeRest  = PlayerPrefs.GetFloat("G923_BrakeRest",  1f);
+    _brakePress = PlayerPrefs.GetFloat("G923_BrakePress", -1f);
+    _clutchRest  = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_REST,  -1f);
+    _clutchPress = PlayerPrefs.GetFloat(PREF_G923_CLUTCH_PRESS,  1f);
+}
+```
+
+### Cambio 2 — `MenuScreenManager.SanityCheckThenLoad` línea ~3434
+
+```csharp
+bool isHori = dev != null && UIInputNew.IsHORITruck(dev);
+float gasRest    = isHori ? 0f  : PlayerPrefs.GetFloat("G923_GasRest", 0f);
+float brakeRest  = isHori ? -1f : PlayerPrefs.GetFloat("G923_BrakeRest", 0f);
+float clutchRest = isHori ? -1f : PlayerPrefs.GetFloat(UIInputNew.PREF_G923_CLUTCH_REST, -1f);
+```
+
+Esto hace que el sanity check use los hardcoded constants para HORI, ignorando
+basura del registry. Sin esto, el sanity check seguía fallando y borrando prefs.
+
+### Cambio 3 — eliminada migración v1.6.3
+
+Ya no hace falta detectar prefs corruptas y borrarlas: UIInputNew las ignora
+para HORI. Menos código, menos paths de error.
+
+## Lecciones tácticas
+
+### 1. Las PlayerPrefs `G923_*` son storage compartido para todos los wheels
+
+El nombre legacy despista. Cuando hay HORI conectado, el código lee y escribe a
+las mismas keys `G923_BrakeAxis`/`G923_BrakeRest`/`G923_BrakePress`. No hay keys
+`HORI_*` separadas. Para evitar confusión, en código futuro: comentar
+explícitamente que estas keys son wheel-agnostic.
+
+### 2. Discovery no es robusto a posiciones iniciales del pedal
+
+El `SnapshotPedalRests` asume que el operador realmente suelta los pedales en
+los primeros 100ms del Phase 4. En la práctica:
+- Operador con pie casual sobre el pedal → captura mal el rest
+- Pedal con resorte débil → no vuelve a -1 fast enough → captura intermedio
+- Reconnect del USB durante el snapshot → control stale → captura garbage
+
+Para hardware con pedales conocidos hardware-fijos (HORI), no hay razón para
+"capturar" rest/press. Hardcodearlos. Discovery solo debería identificar el
+**axis path** (qué canal HID es brake vs clutch).
+
+### 3. Sanity check destructivo + Discovery frágil = loop infinito
+
+Cuando una calibración mala dispara sanity check, sanity borra las prefs,
+Pantalla 2 vuelve a Discovery, operador captura mal otra vez, sanity falla
+otra vez al siguiente boot, ciclo infinito. La solución más limpia es
+**no permitir que sanity check toque hardware-fixed values** (bypass
+para HORI), como hicimos en v1.6.4.
+
+### 4. Reg-write directo no resuelve nada si el código sobrescribe en boot
+
+Escribí `reg add /v G923_BrakeRest /d 0xBF800000` directamente al registry de
+Pasajeros 2. El verify confirmó los valores. Pero al siguiente boot del juego,
+el sanity check los detectó "anómalos" (vs el reading actual) y los borró.
+El registry volvió a basura. **Lección:** cualquier fix manual en el registry
+es transitorio si hay código de Unity que valida y borra esos valores.
+
+### 5. Tailscale device names ≠ portal admin device names
+
+El user me dio la IP `100.66.150.50` con un chat sobre "Pasajeros 2". Esa IP
+en Tailscale es `pasajeros1`. En el portal admin, "Pasajeros 1" es PC del
+"Simulador Urbano 1" (SIM-005), y "Pasajeros 2" es PC del "Simulador Urbano 2"
+(SIM-006). **Verificar siempre** el `pcId` (40 hex) directamente en el portal
+antes de deployar a un kiosko productivo.
+
+### 6. Auto-update OTA no afecta kioskos powered-off
+
+El endpoint `/admin/unity-builds/deploy` con `targetPcIds` ESCRIBE el
+`pendingUpdate` en DynamoDB. El kiosko ejecuta el update en el siguiente
+heartbeat (~3 min). Si está apagado, espera hasta que prenda. **Nunca asumir
+que el deploy se aplicó hasta ver `appVersion` actualizado en el portal.**
+
+### 7. PlayerPrefs en Windows: `_h<hash>` suffix
+
+Las keys en registry tienen sufijo de hash CRC32: `G923_BrakeRest_h1582774858`.
+El sufijo es estable por instalación pero específico del key string y la
+versión de Unity. Nunca asumir el hash; hacer `reg query` y reusar el sufijo
+existente.
+
+REG_DWORD para floats: Unity escribe el float como `Int32` con el bit pattern.
+- `0xBF800000` = float `-1.0`
+- `0x3F800000` = float `+1.0`
+- `0x00000000` = float `0.0`
+
+### 8. HID polling con FILE_FLAG_OVERLAPPED requiere marshalling cuidadoso
+
+Mi primer intento del script `hori-poll.ps1` con overlapped I/O recibía 0
+reports en 30s. El issue: `[ref]$ovl` en PowerShell no marshalea bien. Cambié
+a synchronous `ReadFile` (mismo patrón que `HoriThrottleReader.cs`) y funcionó.
+
+### 9. ReadFile sincrónico bloquea hasta el próximo report HID
+
+Si el dispositivo no manda reports (operator quieto), ReadFile bloquea
+indefinidamente. Para test interactivo, decirle al operador que **mueva
+algo continuamente** durante el polling. O cambiar a OVERLAPPED + WaitForSingleObject
+con timeout.
+
+### 10. SetupAPI vs registry para enumerar HID devices
+
+Mi primer enfoque P/Invoke de SetupDi recibía `cbSize=8` para x64 pero el
+DevicePath salía garbled (truncado a 1 char). El issue: alignment del struct.
+**Mucho más fácil:** enumerar paths via registry en
+`HKLM\SYSTEM\CurrentControlSet\Control\DeviceClasses\{4d1e55b2-f16f-11cf-88cb-001111000030}`.
+Decode: subkey `##?#HID#VID_...` → path `\\?\HID#VID_...`.
+
+### 11. Detección de HORI por strings es preexistente y es un punto débil
+
+`UIInputNew.IsHORITruck(device)` retorna `displayName.Contains("HORI") ||
+product.Contains("HORI")`. Si Windows enumera el HORI como genérico (rare pero
+posible), `IsHORITruck` retorna `false` → cae en path G923 → defaults
+incorrectos. El fix v1.6.4 hereda este riesgo. Mejora futura: detectar también
+por VID/PID (`0x0F0D` / `0x017A`) directo.
+
+### 12. Codex como reviewer crítico atrapó cosas
+
+Antes del build de v1.6.2 y v1.6.4, le pasé los planes a `mcp__codex__codex` con
+"sé crítico, dilo si hay agujeros". Detectó:
+- v1.6.2 plan: "el modal 'Continuar con guardada' no rescata estado sano,
+  preserva el malo" → drop esa idea, hicimos solo el whitelist.
+- v1.6.4 plan: confirmó OK pero recordó el riesgo de detección por strings.
+
+Vale el costo de la consulta para fixes que tocan paths de input.
+
+### 13. SSH a kiosko productivo: leer es OK, escribir requiere autorización
+
+El classifier bloquea operaciones destructivas / escrituras en producción.
+Para `reg add`, `taskkill`, etc., necesité autorización explícita del user.
+**Buen sistema** — previene accidentes. Para reads (`reg query`,
+`Get-Content Player.log`, `tasklist`) pasa sin fricción.
+
+### 14. `aws s3 cp` para uploads está PROHIBIDO desde el mac
+
+Memory `feedback_no_aws_s3_for_uploads.md`: XFinity bloquea S3 PUT desde la red
+del user. Para subir release notes md y artefactos, **siempre vía API de
+Mexicalabs** (`/admin/unity-builds/part-proxy` → `complete-upload`). Recordatorio
+útil — fallé varias veces hasta que volví a leer la memory.
+
+### 15. Logs de Unity tienen 2 fuentes y rotación
+
+- `Player.log` — Unity nativo. Se REINICIA cada launch (overwrite). Vive en
+  `%USERPROFILE%\AppData\LocalLow\<Company>\<Product>\Player.log`.
+- `current.log` — `LogUploader.cs` (custom) buffer persistente. Cada 5 min sube
+  a S3 (`s3://simtabasco-simulator-logs-{env}/logs/{pcId}/...`) y trunca el
+  archivo local. Vive en `<persistentDataPath>/logs/current.log`.
+
+Para diagnostic en vivo: `Player.log` (current session, frágil). Para histórico:
+S3 vía portal admin.
+
+## Pendientes / mejora long-term
+
+- [ ] **Eliminar `_h<hash>` sufijo dependence**: si Unity bumps a una versión
+  con CRC32 diferente, los hashes existentes se vuelven huérfanos. Actualmente
+  no es problema pero sí frágil.
+- [ ] **Detección HORI por VID/PID en lugar de displayName**: ver lección 11.
+- [ ] **Discovery solo identifica axis para HORI**: actualmente Phase 4 brake
+  guarda axis + rest/press. Para HORI, los rest/press son ignorados. Limpiar
+  el código para que Phase 4/6 no escriba rest/press cuando IsHORITruck.
+- [ ] **Sanity check más inteligente**: en lugar de "si delta > 0.5 invalidar",
+  validar contra los rangos hardware esperados. Si HORI brake espera -1..+1,
+  pero el axis reporta 0..255 raw, esa es la señal real de "axis incorrecto"
+  vs "operator tocó el pedal".
+- [ ] **Test unitario de `NormalizePedal` con casos extremos**: divide-by-zero,
+  span negativo, raw fuera de [rest, press], inversión de polaridad. Hubiera
+  pillado el bug original sin necesidad de un kiosko.
+
+## Archivos tocados en v1.6.4
+
+- `2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs:1448-1471`
+- `2026MVP/Assets/Custom/Menu/MenuScreenManager.cs:3434-3442` (sanity check)
+- `2026MVP/Assets/Custom/Menu/MenuScreenManager.cs:2107-2110` (migración v1.6.3 removida)
+- `2026MVP/ProjectSettings/ProjectSettings.asset` (bundleVersion)
+
+## Scripts útiles que quedaron en `/tmp` (Mac) y `Desktop` (Pasajeros 2)
+
+- `hori-poll.ps1` — abre HORI HID col01 directo, imprime byte changes. Útil
+  para mapear bytes ↔ pedales/botones sin dependencia de Unity.
+- `run-pedales.bat`, `run-cajavel.bat`, `run-utilidades.bat` — wrappers con
+  instrucciones para el operador. Cada uno corre el .ps1 con args distintos
+  y guarda output a archivo separado.
+- `calibrate-hori-pedals.ps1` — helper de read/write de PlayerPrefs G923_*
+  con phases (read latest axes, kill game, write float, list prefs). No
+  necesario tras v1.6.4 pero útil para diagnóstico futuro.

--- a/2026MVP/HORI_THROTTLE_BUG_RESOLUTION.md
+++ b/2026MVP/HORI_THROTTLE_BUG_RESOLUTION.md
@@ -343,7 +343,8 @@ Hot-plug: `Update()` retry every 2s si el poller muere. `OnDestroy` cierra handl
 
 ### `Assets/Custom/Menu/MenuScreenManager.cs`
 
-Phase 3 (gas) de Pantalla 2 auto-pasa para HORI con el sentinel. Discovery sigue normal para steering/brake/clutch.
+**v1.5.12** — Phase 3 (gas) de Pantalla 2 auto-pasaba para HORI con el sentinel
+(sin verificar el reader). Discovery sigue normal para steering/brake/clutch.
 
 ```csharp
 if (!throttleDone) {
@@ -359,6 +360,45 @@ if (!throttleDone) {
     // Discovery normal para non-HORI...
 }
 ```
+
+**v1.6.5 (Fase B5)** — el auto-pass se reemplazó con verificación en vivo
+del reader. Ver `HORI_CALIBRATION_LESSONS.md` sección "v1.6.5 — Fase B5".
+Resumen:
+
+```csharp
+if (!throttleDone) {
+    var devForGas = TryAttachToDevice();
+    if (devForGas != null && UIInputNew.IsHORITruck(devForGas)) {
+        if (_horiPhase3StartTime < 0f) _horiPhase3StartTime = Time.unscaledTime;
+        var thrReader = HoriThrottleReader.Instance;
+        float thrValue = thrReader != null ? thrReader.Value : 0f;
+        bool thrHandleOpen = thrReader != null && thrReader.IsHandleOpen;
+
+        // Progress bar en vivo + threshold
+        if (thrHandleOpen && thrValue >= 0.7f) {
+            throttleDone = true;
+            PlayerPrefs.SetString("G923_GasAxis", UIInputNew.HORI_RAW_GAS_PATH);
+            PlayerPrefs.SetFloat("G923_GasRest", 0f);
+            PlayerPrefs.SetFloat("G923_GasPress", 1f);
+            wheelPrompt.text = "Pisa el FRENO a fondo";
+            return;
+        }
+        // Si el handle no abrió tras 8s, advertencia visible. Reader sigue
+        // intentando reabrir cada 2s — conectar USB recupera la fase.
+        return;
+    }
+    // Discovery normal para non-HORI...
+}
+```
+
+`HoriThrottleReader.IsHandleOpen` es nuevo getter (v1.6.5):
+
+```csharp
+public bool IsHandleOpen => _running && _hidHandle != null && !_hidHandle.IsInvalid;
+```
+
+F7 LogConsolePanel imprime `handle=open|CLOSED` en la sección "CUSTOM HID READERS"
+para diagnóstico paralelo (v1.6.5 Fase A).
 
 ## 7. Garantía de no romper G923
 

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.6.6
+  bundleVersion: 1.6.7
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.6.3
+  bundleVersion: 1.6.4
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.6.2
+  bundleVersion: 1.6.3
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.5.12
+  bundleVersion: 1.6.2
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.6.4
+  bundleVersion: 1.6.5
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0

--- a/2026MVP/ProjectSettings/ProjectSettings.asset
+++ b/2026MVP/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.6.5
+  bundleVersion: 1.6.6
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
## Summary

Cadena de 11 commits que resuelve los bugs HORI Truck reportados durante 2026-05-08 a 2026-05-11. Incluye 6 builds (v1.6.2 → v1.6.7), validados en producción (pasajeros1, pasajeros2) y kiosko Aramis.

### Versiones incluidas

| Build | Cambio |
|---|---|
| **v1.6.2** | Whitelist brake axes en Discovery (rechaza axes fantasma `z`, `stick/y`, etc.) |
| **v1.6.3** | Migración de calibración corrupta (loop infinito en sanity check, eventualmente revertida) |
| **v1.6.4** | Pedales HORI hardware-fijos a `rest=-1/press=+1` hardcoded en UIInputNew. Soluciona bug raíz "carro no avanza" cuando PlayerPrefs G923_*Press=0 corruptas. Sanity check bypass HORI. |
| **v1.6.5** | Hardening: F7 muestra `HoriThrottleReader` + `HoriShifterReader`, detección VID/PID 0x0F0D, Phase 4/6 no escribe rest/press para HORI, gates axis-only en `pedalsCal`/`clutchPathPersisted`, sanity hardware-aware con ventana 3 frames, `InputMath.NormalizePedal` extraído + 10 tests EditMode (incluye regression test del bug v1.6.3), Phase 3 verifica `HoriThrottleReader.Value > 0.7` antes de gameplay. |
| **v1.6.6** | Integra `HoriShifterStateProvider` en `desiredGear` para HORI. Soluciona 3ra-6ta PULSE intermitentes en HPC-044U via lectura continua de byte HID. |
| **v1.6.7** | Neutral debounce HORI-only (300ms). Soluciona bug "atorado a 20 km/h" introducido por v1.6.6 — transitorio Neutral del reader durante cruce de gates físicos. |

### Test Plan

- [x] **Aramis (HORI + G923, kiosko pruebas)**: v1.6.7 deployed via LAN scp. Operador confirmó "funcionó" en cambio 2da→3ra con y sin clutch.
- [x] **pasajeros1, pasajeros2**: v1.6.4 deployed via OTA, resolvió "carro no avanza" reportado 2026-05-08.
- [x] **EditMode tests**: 10/10 pasan, incluyendo regression test caso v1.6.3 `NormalizePedal(-1, 1, 0)=1.0`.
- [x] **Build verificación**: bundleVersion 1.6.7, sha256 `49918de1...`, 820 MB en CDN Mexicalabs (isLatest=true).
- [ ] **Pendiente**: OTA deploy a carga, ambulancia (HORI productivos), sedan1/sedan2 (G923 regression test).

### Co-validación

Codex review iterativo (5 pasadas v1.6.5, 1 pasada v1.6.7) atrapó:
- v3 review: rechazó extracción autónoma de profiles para G923/Moto (riesgo regresión). Aprobó "spec providers" pattern.
- v4 review: ajustó gates de `pedalsCal` axis-only para HORI (sin esto rompe fast-path).
- v5 review (v1.6.7): rechazó "permitir cambio sin clutch + rechino" (rompe pedagogía Manual). Aprobó Neutral debounce HORI-only.

### Documentación completa

- `2026MVP/HORI_CALIBRATION_LESSONS.md` — historia de las 7 fases con root cause + fix + edge cases + por qué cada decisión.
- `2026MVP/CLAUDE.md` sección HORI — resumen ejecutivo de cada versión.
- `2026MVP/AGENTS.md` (nuevo) — project guardrails (no tocar Gley/RCCP/EasyRoads/Skybox salvo justificación).
- `2026MVP/HORI_THROTTLE_BUG_RESOLUTION.md` — actualizado con cambio Phase 3 v1.6.5.

### Archivos clave modificados

- `2026MVP/Assets/Gley/UrbanAssets/Runtime/Scripts/UI/UIInputNew.cs` — IsHORITruck VID/PID, gear apply logic, Neutral debounce
- `2026MVP/Assets/Custom/Menu/MenuScreenManager.cs` — Phase 3 verify, sanity hardware-aware, gates axis-only
- `2026MVP/Assets/Custom/HoriThrottleReader.cs` — IsHandleOpen property
- `2026MVP/Assets/Custom/LogConsolePanel.cs` — sección CUSTOM HID READERS
- `2026MVP/Assets/Custom/SimulatorApiClient.cs` — canonical HORI rest/press
- `2026MVP/Assets/Custom/InputMath/` (nuevo) — helper + asmdef testable
- `2026MVP/Assets/Tests/EditMode/` (nuevo) — InputMathTests con regression cases
- `2026MVP/ProjectSettings/ProjectSettings.asset` — bundleVersion 1.5.12 → 1.6.7

### Garantías de no regresión

- G923 PS/Xbox: todas las modificaciones gateadas por `IsHORITruck`. Comportamiento bit-a-bit idéntico a v1.5.12 para Logitech.
- Moto controller: rama `AttachAsMotoSimulator` intacta, no gateada por HORI.
- `NormalizePedal` extraído via delegate injection: default inline en UIInputNew = bit-by-bit idéntico a impl original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)